### PR TITLE
Reduce down to just the needed support lib

### DIFF
--- a/lottie/build.gradle
+++ b/lottie/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.support:support-core-ui:25.1.1'
     testCompile 'junit:junit:4.12'
     testCompile "org.robolectric:robolectric:3.1.2"
 }


### PR DESCRIPTION
Currently, Lottie is relying on app-compat, when in reality, it only needs `support-annotations` and `support-core-ui`

Though most apps probably already rely on appcompat, this will reduce bloat for those that do not. 