### PR TITLE
Remove play services lib from Travis to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ android:
     - extra-google-google_play_services
     - extra-android-m2repository
     - extra-android-support
-    - extra-google-m2repository
 
 after_success:
   - .buildscript/deploy_snapshot.sh


### PR DESCRIPTION
Play Services is not needed for this project, so not pulling down this dependency will speed up the Travis builds.

Not sure why it is modifying that last line, just an artifact of using the GitHub editor I suppose 😄 