### PR TITLE
Remove support lib and play services from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ android:
     - platform-tools
     - build-tools-25.0.2
     - android-25
-    - extra-google-google_play_services
     - extra-android-m2repository
-    - extra-android-support
 
 after_success:
   - .buildscript/deploy_snapshot.sh


### PR DESCRIPTION
Sorry, this should have been in https://github.com/airbnb/lottie-android/pull/22 but I missed them somehow. Neither of these are needed for the Travis build, so it should speed up the time taken on builds a bit.