### PR TITLE
Invalidate LottieDrawable with itself so that it can be verified

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/layers/AnimatableLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/layers/AnimatableLayer.java
@@ -106,6 +106,13 @@ public class AnimatableLayer extends Drawable {
         canvas.restoreToCount(saveCount);
     }
 
+    @Override
+    public void invalidateSelf() {
+        if (parentLayer != null) {
+            parentLayer.invalidateSelf();
+        }
+    }
+
     int saveCanvas(@Nullable Canvas canvas) {
         if (canvas == null) {
             return 0;

--- a/lottie/src/main/java/com/airbnb/lottie/layers/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/layers/LottieDrawable.java
@@ -132,7 +132,10 @@ public class LottieDrawable extends AnimatableLayer {
 
     @Override
     public void invalidateSelf() {
-        super.invalidateSelf();
+        final Callback callback = getCallback();
+        if (callback != null) {
+            callback.invalidateDrawable(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
Previously, LottieDrawable would invalidate itself with whatever layer changed. This would fail verification in [View](https://github.com/android/platform_frameworks_base/blob/master/core/java/android/view/View.java#L17951).

This bubbles up invalidate calls so that the drawable will invalidate itself with `LottieDrawable`.

Fixes #37 