### PR TITLE
Only update lottie drawable if composition changes

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -244,7 +244,14 @@ public class LottieAnimationView extends AppCompatImageView {
       Log.v(TAG, "Set Composition \n" + composition);
     }
     lottieDrawable.setCallback(this);
-    lottieDrawable.setComposition(composition);
+
+    boolean isNewComposition = lottieDrawable.setComposition(composition);
+    if (!isNewComposition) {
+      // We can avoid re-setting the drawable, and invalidating the view, since the composition
+      // hasn't changed.
+      return;
+    }
+
     // If you set a different composition on the view, the bounds will not update unless
     // the drawable is different than the original.
     setImageDrawable(null);

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -115,7 +115,10 @@ public class LottieDrawable extends AnimatableLayer implements Drawable.Callback
     }
   }
 
-  void setComposition(LottieComposition composition) {
+  /**
+   * @return True if the composition is different from the previously set composition, false otherwise.
+   */
+  boolean setComposition(LottieComposition composition) {
     if (getCallback() == null) {
       throw new IllegalStateException(
           "You or your view must set a Drawable.Callback before setting the composition. This " +
@@ -123,6 +126,11 @@ public class LottieDrawable extends AnimatableLayer implements Drawable.Callback
               "Either call ImageView.setImageDrawable() before setComposition() or call " +
               "setCallback(yourView.getCallback()) first.");
     }
+
+    if (this.composition == composition) {
+      return false;
+    }
+
     clearComposition();
     this.composition = composition;
     setSpeed(speed);
@@ -130,6 +138,7 @@ public class LottieDrawable extends AnimatableLayer implements Drawable.Callback
     buildLayersForComposition(composition);
 
     setProgress(getProgress());
+    return true;
   }
 
   private void clearComposition() {


### PR DESCRIPTION
@gpeal 

Addresses https://github.com/airbnb/lottie-android/issues/149

Any ideas on the best way to test this? I looked at the test robot and it only sets a composition once, so that wouldn't catch any issues with a second composition not working correctly. I couldn't think of good way to test this without creating a new test approach. Seems like a robot method that sets the same composition twice, and then different compositions, on the same view would work.