### PR TITLE
Extract factories for Animatable classes

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableColorValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableColorValue.java
@@ -27,7 +27,7 @@ class AnimatableColorValue extends BaseAnimatableValue<Integer, Integer> {
 
     static AnimatableColorValue newInstance(JSONObject json, LottieComposition composition) {
       AnimatableValueParser.Result<Integer> result = AnimatableValueParser
-          .newInstance(json, 1f, composition, new ColorFactory())
+          .newInstance(json, 1f, composition, ColorFactory.INSTANCE)
           .parseJson();
       return new AnimatableColorValue(result.keyframes, composition, result.initialValue);
     }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableColorValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableColorValue.java
@@ -2,13 +2,12 @@ package com.airbnb.lottie;
 
 import org.json.JSONObject;
 
-class AnimatableColorValue extends BaseAnimatableValue<Integer, Integer> {
-  AnimatableColorValue(JSONObject json, LottieComposition composition) {
-    super(json, composition, false);
-  }
+import java.util.List;
 
-  @Override public Integer valueFromObject(Object object, float scale) {
-    return ColorFactory.newInstance(object);
+class AnimatableColorValue extends BaseAnimatableValue<Integer, Integer> {
+  private AnimatableColorValue(List<Keyframe<Integer>> keyframes, LottieComposition composition,
+      Integer initialValue) {
+    super(keyframes, composition, initialValue);
   }
 
   @Override public KeyframeAnimation<Integer> createAnimation() {
@@ -20,5 +19,17 @@ class AnimatableColorValue extends BaseAnimatableValue<Integer, Integer> {
 
   @Override public String toString() {
     return "AnimatableColorValue{" + "initialValue=" + initialValue + '}';
+  }
+
+  static final class Factory {
+    private Factory() {
+    }
+
+    static AnimatableColorValue newInstance(JSONObject json, LottieComposition composition) {
+      AnimatableValueParser.Result<Integer> result = AnimatableValueParser
+          .newInstance(json, 1f, composition, new ColorFactory())
+          .parseJson();
+      return new AnimatableColorValue(result.keyframes, composition, result.initialValue);
+    }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableFloatValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableFloatValue.java
@@ -6,8 +6,7 @@ import java.util.List;
 
 class AnimatableFloatValue extends BaseAnimatableValue<Float, Float> {
   private AnimatableFloatValue(LottieComposition composition, Float initialValue) {
-    super(composition);
-    this.initialValue = initialValue;
+    super(composition, initialValue);
   }
 
   private AnimatableFloatValue(List<Keyframe<Float>> keyframes,

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableFloatValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableFloatValue.java
@@ -2,22 +2,17 @@ package com.airbnb.lottie;
 
 import org.json.JSONObject;
 
+import java.util.List;
+
 class AnimatableFloatValue extends BaseAnimatableValue<Float, Float> {
-  AnimatableFloatValue(LottieComposition composition, Float initialValue) {
+  private AnimatableFloatValue(LottieComposition composition, Float initialValue) {
     super(composition);
     this.initialValue = initialValue;
   }
 
-  AnimatableFloatValue(JSONObject json, LottieComposition composition) {
-    this(json, composition, true);
-  }
-
-  AnimatableFloatValue(JSONObject json, LottieComposition composition, boolean isDp) {
-    super(json, composition, isDp);
-  }
-
-  @Override public Float valueFromObject(Object object, float scale) {
-    return JsonUtils.valueFromObject(object) * scale;
+  private AnimatableFloatValue(List<Keyframe<Float>> keyframes,
+      LottieComposition composition, Float initialValue) {
+    super(keyframes, composition, initialValue);
   }
 
   @Override public KeyframeAnimation<Float> createAnimation() {
@@ -30,5 +25,38 @@ class AnimatableFloatValue extends BaseAnimatableValue<Float, Float> {
 
   public Float getInitialValue() {
     return initialValue;
+  }
+
+  private static class ValueFactory implements AnimatableValue.Factory<Float> {
+    static final ValueFactory INSTANCE = new ValueFactory();
+
+    private ValueFactory() {
+    }
+
+    @Override public Float valueFromObject(Object object, float scale) {
+      return JsonUtils.valueFromObject(object) * scale;
+    }
+  }
+
+  static final class Factory {
+    private Factory() {
+    }
+
+    static AnimatableFloatValue newInstance(LottieComposition composition, Float initialValue) {
+      return new AnimatableFloatValue(composition, initialValue);
+    }
+
+    static AnimatableFloatValue newInstance(JSONObject json, LottieComposition composition) {
+      return newInstance(json, composition, true);
+    }
+
+    static AnimatableFloatValue newInstance(JSONObject json, LottieComposition composition,
+        boolean isDp) {
+      float scale = isDp ? composition.getScale() : 1f;
+      AnimatableValueParser.Result<Float> result = AnimatableValueParser
+          .newInstance(json, scale, composition, ValueFactory.INSTANCE)
+          .parseJson();
+      return new AnimatableFloatValue(result.keyframes, composition, result.initialValue);
+    }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableIntegerValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableIntegerValue.java
@@ -58,6 +58,9 @@ class AnimatableIntegerValue extends BaseAnimatableValue<Integer, Integer> {
   private static class ValueFactory implements AnimatableValue.Factory<Integer> {
     private static final ValueFactory INSTANCE = new ValueFactory();
 
+    private ValueFactory() {
+    }
+
     @Override public Integer valueFromObject(Object object, float scale) {
       return Math.round(JsonUtils.valueFromObject(object) * scale);
     }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableIntegerValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableIntegerValue.java
@@ -6,8 +6,7 @@ import java.util.List;
 
 class AnimatableIntegerValue extends BaseAnimatableValue<Integer, Integer> {
   private AnimatableIntegerValue(LottieComposition composition, Integer initialValue) {
-    super(composition);
-    this.initialValue = initialValue;
+    super(composition, initialValue);
   }
 
   private AnimatableIntegerValue(List<Keyframe<Integer>> keyframes, LottieComposition composition,

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableIntegerValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableIntegerValue.java
@@ -2,27 +2,17 @@ package com.airbnb.lottie;
 
 import org.json.JSONObject;
 
+import java.util.List;
+
 class AnimatableIntegerValue extends BaseAnimatableValue<Integer, Integer> {
-  AnimatableIntegerValue(LottieComposition composition, Integer initialValue) {
+  private AnimatableIntegerValue(LottieComposition composition, Integer initialValue) {
     super(composition);
     this.initialValue = initialValue;
   }
 
-  AnimatableIntegerValue(JSONObject json, LottieComposition composition,
-      boolean isDp, boolean remap100To255) {
-    super(json, composition, isDp);
-    if (remap100To255) {
-      initialValue = initialValue * 255 / 100;
-      for (int i = 0; i < keyframes.size(); i++) {
-        Keyframe<Integer> keyframe = keyframes.get(i);
-        keyframe.startValue = keyframe.startValue * 255 / 100;
-        keyframe.endValue = keyframe.endValue * 255 / 100;
-      }
-    }
-  }
-
-  @Override public Integer valueFromObject(Object object, float scale) {
-    return Math.round(JsonUtils.valueFromObject(object) * scale);
+  private AnimatableIntegerValue(List<Keyframe<Integer>> keyframes, LottieComposition composition,
+      Integer initialValue) {
+    super(keyframes, composition, initialValue);
   }
 
   @Override public KeyframeAnimation<Integer> createAnimation() {
@@ -35,5 +25,41 @@ class AnimatableIntegerValue extends BaseAnimatableValue<Integer, Integer> {
 
   public Integer getInitialValue() {
     return initialValue;
+  }
+
+  static final class Factory {
+    private Factory() {
+    }
+
+    static AnimatableIntegerValue newInstance(LottieComposition composition, Integer initialValue) {
+      return new AnimatableIntegerValue(composition, initialValue);
+    }
+
+    static AnimatableIntegerValue newInstance(JSONObject json, LottieComposition composition,
+        boolean isDp, boolean remap100To255) {
+      float scale = isDp ? composition.getScale() : 1f;
+      AnimatableValueParser.Result<Integer> result = AnimatableValueParser
+          .newInstance(json, scale, composition, ValueFactory.INSTANCE)
+          .parseJson();
+      Integer initialValue = result.initialValue;
+      if (remap100To255 && result.initialValue != null) {
+        initialValue = result.initialValue * 255 / 100;
+        int size = result.keyframes.size();
+        for (int i = 0; i < size; i++) {
+          Keyframe<Integer> keyframe = result.keyframes.get(i);
+          keyframe.startValue = keyframe.startValue * 255 / 100;
+          keyframe.endValue = keyframe.endValue * 255 / 100;
+        }
+      }
+      return new AnimatableIntegerValue(result.keyframes, composition, initialValue);
+    }
+  }
+
+  private static class ValueFactory implements AnimatableValue.Factory<Integer> {
+    private static final ValueFactory INSTANCE = new ValueFactory();
+
+    @Override public Integer valueFromObject(Object object, float scale) {
+      return Math.round(JsonUtils.valueFromObject(object) * scale);
+    }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatablePathValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatablePathValue.java
@@ -15,8 +15,8 @@ class AnimatablePathValue implements IAnimatablePathValue {
       return new AnimatablePathValue(json.opt("k"), composition);
     } else {
       return new AnimatableSplitDimensionPathValue(
-          new AnimatableFloatValue(json.optJSONObject("x"), composition),
-          new AnimatableFloatValue(json.optJSONObject("y"), composition));
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("x"), composition),
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("y"), composition));
     }
   }
 
@@ -36,7 +36,8 @@ class AnimatablePathValue implements IAnimatablePathValue {
       int length = jsonArray.length();
       for (int i = 0; i < length; i++) {
         JSONObject jsonKeyframe = jsonArray.optJSONObject(i);
-        PathKeyframe keyframe = PathKeyframe.Factory.newInstance(jsonKeyframe, composition, this);
+        PathKeyframe keyframe = PathKeyframe.Factory.newInstance(jsonKeyframe, composition,
+            new ValueFactory());
         keyframes.add(keyframe);
       }
       Keyframe.setEndFrames(keyframes);
@@ -52,10 +53,6 @@ class AnimatablePathValue implements IAnimatablePathValue {
 
     Object firstObject = ((JSONArray) json).opt(0);
     return firstObject instanceof JSONObject && ((JSONObject) firstObject).has("t");
-  }
-
-  @Override public PointF valueFromObject(Object object, float scale) {
-    return JsonUtils.pointFromJsonArray((JSONArray) object, scale);
   }
 
   @Override
@@ -80,5 +77,11 @@ class AnimatablePathValue implements IAnimatablePathValue {
   @Override
   public String toString() {
     return "initialPoint=" + initialPoint;
+  }
+
+  private static class ValueFactory implements AnimatableValue.Factory<PointF> {
+    @Override public PointF valueFromObject(Object object, float scale) {
+      return JsonUtils.pointFromJsonArray((JSONArray) object, scale);
+    }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatablePathValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatablePathValue.java
@@ -37,7 +37,7 @@ class AnimatablePathValue implements IAnimatablePathValue {
       for (int i = 0; i < length; i++) {
         JSONObject jsonKeyframe = jsonArray.optJSONObject(i);
         PathKeyframe keyframe = PathKeyframe.Factory.newInstance(jsonKeyframe, composition,
-            new ValueFactory());
+            ValueFactory.INSTANCE);
         keyframes.add(keyframe);
       }
       Keyframe.setEndFrames(keyframes);
@@ -80,6 +80,11 @@ class AnimatablePathValue implements IAnimatablePathValue {
   }
 
   private static class ValueFactory implements AnimatableValue.Factory<PointF> {
+    private static final Factory<PointF> INSTANCE = new ValueFactory();
+
+    private ValueFactory() {
+    }
+
     @Override public PointF valueFromObject(Object object, float scale) {
       return JsonUtils.pointFromJsonArray((JSONArray) object, scale);
     }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatablePointValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatablePointValue.java
@@ -4,20 +4,31 @@ import android.graphics.PointF;
 
 import org.json.JSONObject;
 
-class AnimatablePointValue extends BaseAnimatableValue<PointF, PointF> {
-  AnimatablePointValue(JSONObject pointValues, LottieComposition composition) {
-    super(pointValues, composition, true);
-  }
+import java.util.List;
 
-  @Override public PointF valueFromObject(Object object, float scale) {
-    return PointFFactory.newInstance(object, scale);
+class AnimatablePointValue extends BaseAnimatableValue<PointF, PointF> {
+  private AnimatablePointValue(List<Keyframe<PointF>> keyframes, LottieComposition composition,
+      PointF initialValue) {
+    super(keyframes, composition, initialValue);
   }
 
   @Override public KeyframeAnimation<PointF> createAnimation() {
     if (!hasAnimation()) {
       return new StaticKeyframeAnimation<>(initialValue);
+    } else {
+      return new PointKeyframeAnimation(keyframes);
+    }
+  }
+
+  static final class Factory {
+    private Factory() {
     }
 
-    return new PointKeyframeAnimation(keyframes);
+    static AnimatablePointValue newInstance(JSONObject json, LottieComposition composition) {
+      AnimatableValueParser.Result<PointF> result = AnimatableValueParser
+          .newInstance(json, composition.getScale(), composition, PointFFactory.INSTANCE)
+          .parseJson();
+      return new AnimatablePointValue(result.keyframes, composition, result.initialValue);
+    }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableScaleValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableScaleValue.java
@@ -2,18 +2,17 @@ package com.airbnb.lottie;
 
 import org.json.JSONObject;
 
+import java.util.List;
+
 class AnimatableScaleValue extends BaseAnimatableValue<ScaleXY, ScaleXY> {
-  AnimatableScaleValue(LottieComposition composition) {
+  private AnimatableScaleValue(LottieComposition composition) {
     super(composition);
     initialValue = new ScaleXY();
   }
 
-  AnimatableScaleValue(JSONObject scaleValues, LottieComposition composition, boolean isDp) {
-    super(scaleValues, composition, isDp);
-  }
-
-  @Override public ScaleXY valueFromObject(Object object, float scale) {
-    return ScaleXY.Factory.newInstance(object, scale);
+  private AnimatableScaleValue(List<Keyframe<ScaleXY>> keyframes, LottieComposition composition,
+      ScaleXY initialValue) {
+    super(keyframes, composition, initialValue);
   }
 
   @Override public KeyframeAnimation<ScaleXY> createAnimation() {
@@ -21,6 +20,24 @@ class AnimatableScaleValue extends BaseAnimatableValue<ScaleXY, ScaleXY> {
       return new StaticKeyframeAnimation<>(initialValue);
     } else {
       return new ScaleKeyframeAnimation(keyframes);
+    }
+  }
+
+  static final class Factory {
+    private Factory() {
+    }
+
+    static AnimatableScaleValue newInstance(JSONObject json, LottieComposition
+        composition, boolean isDp) {
+      float scale = isDp ? composition.getScale() : 1f;
+      AnimatableValueParser.Result<ScaleXY> result = AnimatableValueParser
+          .newInstance(json, scale, composition, ScaleXY.Factory.INSTANCE)
+          .parseJson();
+      return new AnimatableScaleValue(result.keyframes, composition, result.initialValue);
+    }
+
+    static AnimatableScaleValue newInstance(LottieComposition composition) {
+      return new AnimatableScaleValue(composition);
     }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableScaleValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableScaleValue.java
@@ -6,8 +6,7 @@ import java.util.List;
 
 class AnimatableScaleValue extends BaseAnimatableValue<ScaleXY, ScaleXY> {
   private AnimatableScaleValue(LottieComposition composition) {
-    super(composition);
-    initialValue = new ScaleXY();
+    super(composition, new ScaleXY());
   }
 
   private AnimatableScaleValue(List<Keyframe<ScaleXY>> keyframes, LottieComposition composition,

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableShapeValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableShapeValue.java
@@ -4,28 +4,39 @@ import android.graphics.Path;
 
 import org.json.JSONObject;
 
+import java.util.List;
+
 class AnimatableShapeValue extends BaseAnimatableValue<ShapeData, Path> {
   private final Path convertTypePath = new Path();
 
-  AnimatableShapeValue(JSONObject json, LottieComposition composition) {
-    super(json, composition, true);
-  }
-
-  @Override public ShapeData valueFromObject(Object object, float scale) {
-    return ShapeData.Factory.newInstance(object, scale);
+  private AnimatableShapeValue(List<Keyframe<ShapeData>> keyframes, LottieComposition composition,
+      ShapeData initialValue) {
+    super(keyframes, composition, initialValue);
   }
 
   @Override public BaseKeyframeAnimation<?, Path> createAnimation() {
     if (!hasAnimation()) {
       return new StaticKeyframeAnimation<>(convertType(initialValue));
+    } else {
+      return new ShapeKeyframeAnimation(keyframes);
     }
-
-    return new ShapeKeyframeAnimation(keyframes);
   }
 
   @Override Path convertType(ShapeData shapeData) {
     convertTypePath.reset();
     MiscUtils.getPathFromData(shapeData, convertTypePath);
     return convertTypePath;
+  }
+
+  static final class Factory {
+    private Factory() {
+    }
+
+    static AnimatableShapeValue newInstance(JSONObject json, LottieComposition composition) {
+      AnimatableValueParser.Result<ShapeData> result = AnimatableValueParser
+          .newInstance(json, composition.getScale(), composition, ShapeData.Factory.INSTANCE)
+          .parseJson();
+      return new AnimatableShapeValue(result.keyframes, composition, result.initialValue);
+    }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableSplitDimensionPathValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableSplitDimensionPathValue.java
@@ -14,10 +14,6 @@ class AnimatableSplitDimensionPathValue implements IAnimatablePathValue {
     this.animatableYDimension = animatableYDimension;
   }
 
-  @Override public PointF valueFromObject(Object object, float scale) {
-    return null;
-  }
-
   @Override public KeyframeAnimation<PointF> createAnimation() {
     return new SplitDimensionPathKeyframeAnimation(
         animatableXDimension.createAnimation(), animatableYDimension.createAnimation());

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableTransform.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableTransform.java
@@ -25,9 +25,9 @@ class AnimatableTransform {
     static AnimatableTransform newInstance(LottieComposition composition) {
       AnimatablePathValue anchorPoint = new AnimatablePathValue();
       IAnimatablePathValue position = new AnimatablePathValue();
-      AnimatableScaleValue scale = new AnimatableScaleValue(composition);
-      AnimatableFloatValue rotation = new AnimatableFloatValue(composition, 0f);
-      AnimatableIntegerValue opacity = new AnimatableIntegerValue(composition, 255);
+      AnimatableScaleValue scale = AnimatableScaleValue.Factory.newInstance(composition);
+      AnimatableFloatValue rotation = AnimatableFloatValue.Factory.newInstance(composition, 0f);
+      AnimatableIntegerValue opacity = AnimatableIntegerValue.Factory.newInstance(composition, 255);
       return new AnimatableTransform(anchorPoint, position, scale, rotation, opacity);
     }
 
@@ -54,7 +54,7 @@ class AnimatableTransform {
 
       JSONObject scaleJson = json.optJSONObject("s");
       if (scaleJson != null) {
-        scale = new AnimatableScaleValue(scaleJson, composition, false);
+        scale = AnimatableScaleValue.Factory.newInstance(scaleJson, composition, false);
       } else {
         throwMissingTransform("scale");
       }
@@ -64,14 +64,14 @@ class AnimatableTransform {
         rotationJson = json.optJSONObject("rz");
       }
       if (rotationJson != null) {
-        rotation = new AnimatableFloatValue(rotationJson, composition, false);
+        rotation = AnimatableFloatValue.Factory.newInstance(rotationJson, composition, false);
       } else {
         throwMissingTransform("rotation");
       }
 
       JSONObject opacityJson = json.optJSONObject("o");
       if (opacityJson != null) {
-        opacity = new AnimatableIntegerValue(opacityJson, composition, false, true);
+        opacity = AnimatableIntegerValue.Factory.newInstance(opacityJson, composition, false, true);
       } else {
         throwMissingTransform("opacity");
       }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableValue.java
@@ -1,7 +1,10 @@
 package com.airbnb.lottie;
 
 interface AnimatableValue<V, O> {
-  V valueFromObject(Object object, float scale);
   BaseKeyframeAnimation<?, O> createAnimation();
   boolean hasAnimation();
+
+  interface Factory<V> {
+    V valueFromObject(Object object, float scale);
+  }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/AnimatableValueParser.java
+++ b/lottie/src/main/java/com/airbnb/lottie/AnimatableValueParser.java
@@ -1,0 +1,79 @@
+package com.airbnb.lottie;
+
+import android.support.annotation.Nullable;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Collections;
+import java.util.List;
+
+class AnimatableValueParser<T> {
+  @Nullable private final JSONObject json;
+  private final float scale;
+  private final LottieComposition composition;
+  private final AnimatableValue.Factory<T> valueFactory;
+
+  private AnimatableValueParser(@Nullable JSONObject json, float scale, LottieComposition
+      composition, AnimatableValue.Factory<T> valueFactory) {
+    this.json = json;
+    this.scale = scale;
+    this.composition = composition;
+    this.valueFactory = valueFactory;
+  }
+
+  static <T> AnimatableValueParser<T> newInstance(@Nullable JSONObject json, float scale,
+      LottieComposition composition, AnimatableValue.Factory<T> valueFactory) {
+    return new AnimatableValueParser<>(json, scale, composition, valueFactory);
+  }
+
+  Result<T> parseJson() {
+    List<Keyframe<T>> keyframes = parseKeyframes();
+    T initialValue = parseInitialValue(keyframes);
+    return new Result<>(keyframes, initialValue);
+  }
+
+  private List<Keyframe<T>> parseKeyframes() {
+    if (json != null) {
+      Object k = json.opt("k");
+      if (hasKeyframes(k)) {
+        return Keyframe.Factory.parseKeyframes((JSONArray) k, composition, scale, valueFactory);
+      } else {
+        return Collections.emptyList();
+      }
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  @Nullable private T parseInitialValue(List<Keyframe<T>> keyframes) {
+    if (json != null) {
+      if (!keyframes.isEmpty()) {
+        return keyframes.get(0).startValue;
+      } else {
+        return valueFactory.valueFromObject(json.opt("k"), scale);
+      }
+    } else {
+      return null;
+    }
+  }
+
+  private static boolean hasKeyframes(Object json) {
+    if (!(json instanceof JSONArray)) {
+      return false;
+    } else {
+      Object firstObject = ((JSONArray) json).opt(0);
+      return firstObject instanceof JSONObject && ((JSONObject) firstObject).has("t");
+    }
+  }
+
+  static class Result<T> {
+    final List<Keyframe<T>> keyframes;
+    final @Nullable T initialValue;
+
+    Result(List<Keyframe<T>> keyframes, @Nullable T initialValue) {
+      this.keyframes = keyframes;
+      this.initialValue = initialValue;
+    }
+  }
+}

--- a/lottie/src/main/java/com/airbnb/lottie/BaseAnimatableValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/BaseAnimatableValue.java
@@ -1,57 +1,26 @@
 package com.airbnb.lottie;
 
-import android.support.annotation.Nullable;
-
-import org.json.JSONArray;
-import org.json.JSONObject;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 abstract class BaseAnimatableValue<V, O> implements AnimatableValue<V, O> {
-  List<Keyframe<V>> keyframes = Collections.emptyList();
+  final List<Keyframe<V>> keyframes;
   final LottieComposition composition;
-  private final boolean isDp;
-
   V initialValue;
 
-  /** Create a default static animatable path. */
+  /**
+   * Create a default static animatable path.
+   */
   BaseAnimatableValue(LottieComposition composition) {
     this.composition = composition;
-    isDp = false;
+    this.keyframes = Collections.emptyList();
   }
 
-  BaseAnimatableValue(@Nullable JSONObject json, LottieComposition composition, boolean isDp) {
+  BaseAnimatableValue(List<Keyframe<V>> keyframes, LottieComposition composition, V initialValue) {
+    this.keyframes = keyframes;
     this.composition = composition;
-    this.isDp = isDp;
-    if (json != null) {
-      Object k = json.opt("k");
-      if (hasKeyframes(k)) {
-        keyframes = Keyframe.Factory.parseKeyframes((JSONArray) k, composition, getScale(), this);
-        if (!keyframes.isEmpty()) {
-          initialValue = keyframes.get(0).startValue;
-        }
-      } else {
-        initialValue = valueFromObject(k, getScale());
-      }
-      if (keyframes == null) {
-        keyframes = Collections.emptyList();
-      }
-    }
-  }
-
-  private boolean hasKeyframes(Object json) {
-    if (!(json instanceof JSONArray)) {
-      return false;
-    }
-
-    Object firstObject = ((JSONArray) json).opt(0);
-    return firstObject instanceof JSONObject && ((JSONObject) firstObject).has("t");
-  }
-
-  private float getScale() {
-    return isDp ? composition.getScale() : 1f;
+    this.initialValue = initialValue;
   }
 
   /**
@@ -75,7 +44,7 @@ abstract class BaseAnimatableValue<V, O> implements AnimatableValue<V, O> {
 
   @Override public String toString() {
     final StringBuilder sb = new StringBuilder();
-    sb.append("initialValue=").append(initialValue);
+    sb.append("parseInitialValue=").append(initialValue);
     if (!keyframes.isEmpty()) {
       sb.append(", values=").append(Arrays.toString(keyframes.toArray()));
     }

--- a/lottie/src/main/java/com/airbnb/lottie/BaseAnimatableValue.java
+++ b/lottie/src/main/java/com/airbnb/lottie/BaseAnimatableValue.java
@@ -7,14 +7,13 @@ import java.util.List;
 abstract class BaseAnimatableValue<V, O> implements AnimatableValue<V, O> {
   final List<Keyframe<V>> keyframes;
   final LottieComposition composition;
-  V initialValue;
+  final V initialValue;
 
   /**
    * Create a default static animatable path.
    */
-  BaseAnimatableValue(LottieComposition composition) {
-    this.composition = composition;
-    this.keyframes = Collections.emptyList();
+  BaseAnimatableValue(LottieComposition composition, V initialValue) {
+    this(Collections.<Keyframe<V>>emptyList(), composition, initialValue);
   }
 
   BaseAnimatableValue(List<Keyframe<V>> keyframes, LottieComposition composition, V initialValue) {
@@ -39,8 +38,6 @@ abstract class BaseAnimatableValue<V, O> implements AnimatableValue<V, O> {
   public O getInitialValue() {
     return convertType(initialValue);
   }
-
-  public abstract BaseKeyframeAnimation<?, O> createAnimation();
 
   @Override public String toString() {
     final StringBuilder sb = new StringBuilder();

--- a/lottie/src/main/java/com/airbnb/lottie/CircleShape.java
+++ b/lottie/src/main/java/com/airbnb/lottie/CircleShape.java
@@ -19,7 +19,7 @@ class CircleShape {
       return new CircleShape(
           AnimatablePathValue
               .createAnimatablePathOrSplitDimensionPath(json.optJSONObject("p"), composition),
-          new AnimatablePointValue(json.optJSONObject("s"), composition));
+          AnimatablePointValue.Factory.newInstance(json.optJSONObject("s"), composition));
     }
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/ColorFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ColorFactory.java
@@ -5,6 +5,8 @@ import android.graphics.Color;
 import org.json.JSONArray;
 
 class ColorFactory implements AnimatableValue.Factory<Integer> {
+  static final ColorFactory INSTANCE = new ColorFactory();
+
   @Override public Integer valueFromObject(Object object, float scale) {
     JSONArray colorArray = (JSONArray) object;
     if (colorArray.length() == 4) {

--- a/lottie/src/main/java/com/airbnb/lottie/ColorFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ColorFactory.java
@@ -4,11 +4,8 @@ import android.graphics.Color;
 
 import org.json.JSONArray;
 
-class ColorFactory {
-  private ColorFactory() {
-  }
-
-  static Integer newInstance(Object object) {
+class ColorFactory implements AnimatableValue.Factory<Integer> {
+  @Override public Integer valueFromObject(Object object, float scale) {
     JSONArray colorArray = (JSONArray) object;
     if (colorArray.length() == 4) {
       boolean shouldUse255 = true;

--- a/lottie/src/main/java/com/airbnb/lottie/Keyframe.java
+++ b/lottie/src/main/java/com/airbnb/lottie/Keyframe.java
@@ -87,7 +87,7 @@ public class Keyframe<T> {
     }
 
     static <T> Keyframe<T> newInstance(JSONObject json, LottieComposition composition, float scale,
-        AnimatableValue<T, ?> animatableValue) {
+        AnimatableValue.Factory<T> valueFactory) {
       PointF cp1 = null;
       PointF cp2 = null;
       float startFrame = 0;
@@ -99,12 +99,12 @@ public class Keyframe<T> {
         startFrame = (float) json.optDouble("t", 0);
         Object startValueJson = json.opt("s");
         if (startValueJson != null) {
-          startValue = animatableValue.valueFromObject(startValueJson, scale);
+          startValue = valueFactory.valueFromObject(startValueJson, scale);
         }
 
         Object endValueJson = json.opt("e");
         if (endValueJson != null) {
-          endValue = animatableValue.valueFromObject(endValueJson, scale);
+          endValue = valueFactory.valueFromObject(endValueJson, scale);
         }
 
         JSONObject cp1Json = json.optJSONObject("o");
@@ -127,14 +127,14 @@ public class Keyframe<T> {
           interpolator = LINEAR_INTERPOLATOR;
         }
       } else {
-        startValue = animatableValue.valueFromObject(json, scale);
+        startValue = valueFactory.valueFromObject(json, scale);
         endValue = startValue;
       }
       return new Keyframe<>(composition, startValue, endValue, interpolator, startFrame, null);
     }
 
     static <T> List<Keyframe<T>> parseKeyframes(JSONArray json, LottieComposition composition,
-        float scale, AnimatableValue<T, ?> animatableValue) {
+        float scale, AnimatableValue.Factory<T> valueFactory) {
       int length = json.length();
       if (length == 0) {
         return Collections.emptyList();
@@ -142,7 +142,7 @@ public class Keyframe<T> {
       List<Keyframe<T>> keyframes = new ArrayList<>();
       for (int i = 0; i < length; i++) {
         keyframes.add(Keyframe.Factory.newInstance(json.optJSONObject(i), composition, scale,
-            animatableValue));
+            valueFactory));
       }
 
       setEndFrames(keyframes);

--- a/lottie/src/main/java/com/airbnb/lottie/Mask.java
+++ b/lottie/src/main/java/com/airbnb/lottie/Mask.java
@@ -38,8 +38,8 @@ class Mask {
           maskMode = MaskMode.MaskModeUnknown;
       }
 
-      AnimatableShapeValue maskPath = new AnimatableShapeValue(json.optJSONObject("pt"),
-          composition);
+      AnimatableShapeValue maskPath = AnimatableShapeValue.Factory.newInstance(
+          json.optJSONObject("pt"), composition);
       // TODO: use this
       // JSONObject opacityJson = json.optJSONObject("o");
       // if (opacityJson != null) {

--- a/lottie/src/main/java/com/airbnb/lottie/PathKeyframe.java
+++ b/lottie/src/main/java/com/airbnb/lottie/PathKeyframe.java
@@ -22,9 +22,9 @@ class PathKeyframe extends Keyframe<PointF> {
     }
 
     static PathKeyframe newInstance(JSONObject json, LottieComposition composition,
-        AnimatableValue<PointF, ?> animatableValue) {
+        AnimatableValue.Factory<PointF> valueFactory) {
       Keyframe<PointF> keyframe = Keyframe.Factory.newInstance(json, composition,
-          composition.getScale(), animatableValue);
+          composition.getScale(), valueFactory);
       PointF cp1 = null;
       PointF cp2 = null;
       JSONArray tiJson = json.optJSONArray("ti");

--- a/lottie/src/main/java/com/airbnb/lottie/PointFFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/PointFFactory.java
@@ -5,8 +5,13 @@ import android.graphics.PointF;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-class PointFFactory {
-  static PointF newInstance(Object object, float scale) {
+class PointFFactory implements AnimatableValue.Factory<PointF> {
+  static final PointFFactory INSTANCE = new PointFFactory();
+
+  private PointFFactory() {
+  }
+
+  @Override public PointF valueFromObject(Object object, float scale) {
     if (object instanceof JSONArray) {
       return JsonUtils.pointFromJsonArray((JSONArray) object, scale);
     } else if (object instanceof JSONObject) {

--- a/lottie/src/main/java/com/airbnb/lottie/PolystarShape.java
+++ b/lottie/src/main/java/com/airbnb/lottie/PolystarShape.java
@@ -53,21 +53,23 @@ class PolystarShape {
     static PolystarShape newInstance(JSONObject json, LottieComposition composition) {
       Type type = Type.forValue(json.optInt("sy"));
       AnimatableFloatValue points =
-          new AnimatableFloatValue(json.optJSONObject("pt"), composition, false);
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("pt"), composition, false);
       IAnimatablePathValue position = AnimatablePathValue.createAnimatablePathOrSplitDimensionPath(
           json.optJSONObject("p"), composition);
       AnimatableFloatValue rotation =
-          new AnimatableFloatValue(json.optJSONObject("r"), composition, false);
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("r"), composition, false);
       AnimatableFloatValue outerRadius =
-          new AnimatableFloatValue(json.optJSONObject("or"), composition);
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("or"), composition);
       AnimatableFloatValue outerRoundedness =
-          new AnimatableFloatValue(json.optJSONObject("os"), composition, false);
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("os"), composition, false);
       AnimatableFloatValue innerRadius;
       AnimatableFloatValue innerRoundedness;
 
       if (type == Type.Star) {
-        innerRadius = new AnimatableFloatValue(json.optJSONObject("ir"), composition);
-        innerRoundedness = new AnimatableFloatValue(json.optJSONObject("is"), composition, false);
+        innerRadius =
+            AnimatableFloatValue.Factory.newInstance(json.optJSONObject("ir"), composition);
+        innerRoundedness =
+            AnimatableFloatValue.Factory.newInstance(json.optJSONObject("is"), composition, false);
       } else {
         innerRadius = null;
         innerRoundedness = null;

--- a/lottie/src/main/java/com/airbnb/lottie/RectangleShape.java
+++ b/lottie/src/main/java/com/airbnb/lottie/RectangleShape.java
@@ -22,8 +22,8 @@ class RectangleShape {
       return new RectangleShape(
           AnimatablePathValue.createAnimatablePathOrSplitDimensionPath(
               json.optJSONObject("p"), composition),
-          new AnimatablePointValue(json.optJSONObject("s"), composition),
-          new AnimatableFloatValue(json.optJSONObject("r"), composition));
+          AnimatablePointValue.Factory.newInstance(json.optJSONObject("s"), composition),
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("r"), composition));
     }
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/ScaleXY.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ScaleXY.java
@@ -27,11 +27,13 @@ class ScaleXY {
     return getScaleX() + "x" + getScaleY();
   }
 
-  static class Factory {
+  static class Factory implements AnimatableValue.Factory<ScaleXY> {
+    static final Factory INSTANCE = new Factory();
+
     private Factory() {
     }
 
-    static ScaleXY newInstance(Object object, float scale) {
+    @Override public ScaleXY valueFromObject(Object object, float scale) {
       JSONArray array = (JSONArray) object;
       return new ScaleXY(
           (float) array.optDouble(0, 1) / 100f * scale,

--- a/lottie/src/main/java/com/airbnb/lottie/ShapeData.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ShapeData.java
@@ -97,11 +97,13 @@ class ShapeData {
         '}';
   }
 
-  static class Factory {
+  static class Factory implements AnimatableValue.Factory<ShapeData> {
+    static final ShapeData.Factory INSTANCE = new Factory();
+
     private Factory() {
     }
 
-    static ShapeData newInstance(Object object, float scale) {
+    @Override public ShapeData valueFromObject(Object object, float scale) {
       JSONObject pointsData = null;
       if (object instanceof JSONArray) {
         Object firstObject = ((JSONArray) object).opt(0);

--- a/lottie/src/main/java/com/airbnb/lottie/ShapeFill.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ShapeFill.java
@@ -27,12 +27,12 @@ class ShapeFill {
 
       JSONObject jsonColor = json.optJSONObject("c");
       if (jsonColor != null) {
-        color = new AnimatableColorValue(jsonColor, composition);
+        color = AnimatableColorValue.Factory.newInstance(jsonColor, composition);
       }
 
       JSONObject jsonOpacity = json.optJSONObject("o");
       if (jsonOpacity != null) {
-        opacity = new AnimatableIntegerValue(jsonOpacity, composition, false, true);
+        opacity = AnimatableIntegerValue.Factory.newInstance(jsonOpacity, composition, false, true);
       }
       fillEnabled = json.optBoolean("fillEnabled");
       return new ShapeFill(fillEnabled, color, opacity);

--- a/lottie/src/main/java/com/airbnb/lottie/ShapePath.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ShapePath.java
@@ -18,8 +18,9 @@ class ShapePath {
     }
 
     static ShapePath newInstance(JSONObject json, LottieComposition composition) {
-      return new ShapePath(json.optString("nm"), json.optInt("ind"),
-          new AnimatableShapeValue(json.optJSONObject("ks"), composition));
+      AnimatableShapeValue animatableShapeValue =
+          AnimatableShapeValue.Factory.newInstance(json.optJSONObject("ks"), composition);
+      return new ShapePath(json.optString("nm"), json.optInt("ind"), animatableShapeValue);
     }
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/ShapeStroke.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ShapeStroke.java
@@ -48,10 +48,12 @@ class ShapeStroke {
 
     static ShapeStroke newInstance(JSONObject json, LottieComposition composition) {
       List<AnimatableFloatValue> lineDashPattern = new ArrayList<>();
-      AnimatableColorValue color = new AnimatableColorValue(json.optJSONObject("c"), composition);
-      AnimatableFloatValue width = new AnimatableFloatValue(json.optJSONObject("w"), composition);
-      AnimatableIntegerValue opacity = new AnimatableIntegerValue(json.optJSONObject("o"),
-          composition, false, true);
+      AnimatableColorValue color = AnimatableColorValue.Factory.newInstance(json.optJSONObject("c"),
+          composition);
+      AnimatableFloatValue width = AnimatableFloatValue.Factory.newInstance(json.optJSONObject("w"),
+          composition);
+      AnimatableIntegerValue opacity = AnimatableIntegerValue.Factory.newInstance(
+          json.optJSONObject("o"), composition, false, true);
       LineCapType capType = LineCapType.values()[json.optInt("lc") - 1];
       LineJoinType joinType = LineJoinType.values()[json.optInt("lj") - 1];
       AnimatableFloatValue offset = null;
@@ -63,10 +65,10 @@ class ShapeStroke {
           String n = dashJson.optString("n");
           if (n.equals("o")) {
             JSONObject value = dashJson.optJSONObject("v");
-            offset = new AnimatableFloatValue(value, composition);
+            offset = AnimatableFloatValue.Factory.newInstance(value, composition);
           } else if (n.equals("d") || n.equals("g")) {
             JSONObject value = dashJson.optJSONObject("v");
-            lineDashPattern.add(new AnimatableFloatValue(value, composition));
+            lineDashPattern.add(AnimatableFloatValue.Factory.newInstance(value, composition));
           }
         }
         if (lineDashPattern.size() == 1) {

--- a/lottie/src/main/java/com/airbnb/lottie/ShapeTrimPath.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ShapeTrimPath.java
@@ -20,9 +20,9 @@ class ShapeTrimPath {
 
     static ShapeTrimPath newInstance(JSONObject json, LottieComposition composition) {
       return new ShapeTrimPath(
-          new AnimatableFloatValue(json.optJSONObject("s"), composition, false),
-          new AnimatableFloatValue(json.optJSONObject("e"), composition, false),
-          new AnimatableFloatValue(json.optJSONObject("o"), composition, false));
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("s"), composition, false),
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("e"), composition, false),
+          AnimatableFloatValue.Factory.newInstance(json.optJSONObject("o"), composition, false));
     }
   }
 


### PR DESCRIPTION
In this pass I've converted `BaseAnimatableValue` and its subclasses.
Created a `AnimatableValueParser` with the common logic to all subclasses.
This change caused a "chicken and egg" problem where the `AnimatableValueParser` calls into `Keyframe.Factory.parseKeyframes`, which needs the respective instance of `BaseAnimatableValue`. This caused a circular dependency issue. I've resolved by moving `AnimatableValue#valueFromObject()` into a separate interface called `AnimatableValue.Factory` which contains only that method.
I think almost all the relevant classes have been refactored by now.
Part of #3