### PR TITLE
Cancellable is returned by public functions, but isn't accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ If you want to reuse an animation such as in each item of a list or load it from
 ```java
  LottieAnimationView animationView = (LottieAnimationView) findViewById(R.id.animation_view);
  ...
- LottieComposition composition = LottieComposition.fromJson(getResources(), jsonObject, (composition) -> {
+ Cancellable compositionCancellable = LottieComposition.Factory.fromJson(getResources(), jsonObject, (composition) -> {
      animationView.setComposition(composition);
      animationView.playAnimation();
  });
+
+ // Cancel to stop asynchronous loading of composition
+ // compositionCancellable.cancel();
 ```
 
 You can then control the animation or add listeners:

--- a/lottie/src/main/java/com/airbnb/lottie/Cancellable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/Cancellable.java
@@ -1,5 +1,5 @@
 package com.airbnb.lottie;
 
-interface Cancellable {
+public interface Cancellable {
   void cancel();
 }


### PR DESCRIPTION
You can do this ...
```
LottieComposition.Factory.fromJson(getResources(),
       new JSONObject(), new OnCompositionLoadedListener() {
           @Override
            public void onCompositionLoaded(LottieComposition composition) {
                ...
            }
       });
```

But you cannot do this ...
```
Cancellable compositionCancellable = LottieComposition.Factory.fromJson(getResources(),
       new JSONObject(), new OnCompositionLoadedListener() {
           @Override
            public void onCompositionLoaded(LottieComposition composition) {
                ...
            }
       });

compositionCancellable.cancel();
```

Also on the README.md the examples show the old style ```LottieComposition.fromJson``` as opposed to ```LottieComposition.Factory.fromJson```
