### PR TITLE
Fix invalidateDrawable method behavior for non-Lottie images

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -134,6 +134,9 @@ public class LottieAnimationView extends AppCompatImageView {
       // We always want to invalidate the root drawable to it redraws the whole drawable.
       // Eventually it would be great to be able to invalidate just the changed region.
       super.invalidateDrawable(lottieDrawable);
+    } else {
+      // Otherwise work as regular ImageView
+      super.invalidateDrawable(dr);
     }
   }
 


### PR DESCRIPTION
Update for https://github.com/airbnb/lottie-android/issues/159 — `invalidateDrawable(Drawable)` should call `super` for non-Lottie resources.