### PR TITLE
Assert LottieDrawable when recycling bitmaps

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -192,7 +192,11 @@ public class LottieAnimationView extends AppCompatImageView {
   }
 
   @VisibleForTesting void recycleBitmaps() {
-    lottieDrawable.recycleBitmaps();
+    // AppCompatImageView constructor will set the image when set from xml
+    // before LottieDrawable has been initialized
+    if (lottieDrawable != null) {
+        lottieDrawable.recycleBitmaps();
+    }
   }
 
   /**


### PR DESCRIPTION
* Databinding, when used in tandem with an initial static image can cause the LottieDrawable instance to be null/not intialized.

Issue exists on PIxel XL 7.1.1 and 7.1.2 using latest stable source (1.5.3).