### PR TITLE
Clear curves list of temporary shape before reuse.

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/ShapeKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ShapeKeyframeAnimation.java
@@ -13,6 +13,7 @@ class ShapeKeyframeAnimation extends BaseKeyframeAnimation<ShapeData, Path> {
   }
 
   @Override public Path getValue(Keyframe<ShapeData> keyframe, float keyframeProgress) {
+    tempShapeData.getCurves().clear();
     ShapeData startShapeData = keyframe.startValue;
     ShapeData endShapeData = keyframe.endValue;
 


### PR DESCRIPTION
This is a fix for the crash problem we observed with our animation data (reproduces on the sample Android player too):

06-20 15:58:07.822 29935 29935 E AndroidRuntime: java.lang.IllegalStateException: Curves must have the same number of control points. This: 12» Shape 1: 13»    Shape 2: 13
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.ShapeData.interpolateBetween(ShapeData.java:58)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.ShapeKeyframeAnimation.getValue(ShapeKeyframeAnimation.java:19)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.ShapeKeyframeAnimation.getValue(ShapeKeyframeAnimation.java:7)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.BaseKeyframeAnimation.getValue(BaseKeyframeAnimation.java:109)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.ShapeContent.getPath(ShapeContent.java:54)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.FillContent.draw(FillContent.java:71)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.ContentGroup.draw(ContentGroup.java:185)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.ContentGroup.draw(ContentGroup.java:185)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.ShapeLayer.drawLayer(ShapeLayer.java:24)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.BaseLayer.draw(BaseLayer.java:162)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.CompositionLayer.drawLayer(CompositionLayer.java:75)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.BaseLayer.draw(BaseLayer.java:162)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at com.airbnb.lottie.LottieDrawable.draw(LottieDrawable.java:292)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at android.widget.ImageView.onDraw(ImageView.java:1316)
06-20 15:58:07.822 29935 29935 E AndroidRuntime: »      at android.view.View.draw(View.java:17185)

Thank you.