### PR TITLE
Significant animator overhaul

### DIFF
--- a/lottie/build.gradle
+++ b/lottie/build.gradle
@@ -25,7 +25,7 @@ android {
 dependencies {
   compile "com.android.support:appcompat-v7:$supportLibVersion"
   testCompile 'junit:junit:4.12'
-  testCompile "org.robolectric:robolectric:3.3.2"
+  testCompile "org.robolectric:robolectric:3.4.2"
 }
 
 task javadoc(type: Javadoc) {

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -337,7 +337,7 @@ import java.util.Map;
     }
 
     this.animationName = animationName;
-    lottieDrawable.cancelAnimation();
+    lottieDrawable.clearComposition();
     cancelLoaderTask();
     compositionLoader = LottieComposition.Factory.fromAssetFileName(getContext(), animationName,
         new OnCompositionLoadedListener() {
@@ -415,6 +415,89 @@ import java.util.Map;
     return lottieDrawable.hasMatte();
   }
 
+  /**
+   * Plays the animation from the beginning. If speed is < 0, it will start at the end
+   * and play towards the beginning
+   */
+  public void playAnimation() {
+    lottieDrawable.playAnimation();
+    enableOrDisableHardwareLayer();
+  }
+
+  /**
+   * Continues playing the animation from its current position. If speed < 0, it will play backwards
+   * from the current position.
+   */
+  public void resumeAnimation() {
+    lottieDrawable.resumeAnimation();
+    enableOrDisableHardwareLayer();
+  }
+
+  /**
+   * Sets the minimum frame that the animation will start from when playing or looping.
+   */
+  public void setMinFrame(int startFrame) {
+    lottieDrawable.setMinFrame(startFrame);
+  }
+
+  /**
+   * Sets the minimum progress that the animation will start from when playing or looping.
+   */
+  public void setMinProgress(float startProgress) {
+    lottieDrawable.setMinProgress(startProgress);
+  }
+
+  /**
+   * Sets the maximum frame that the animation will end at when playing or looping.
+   */
+  public void setMaxFrame(int endFrame) {
+    lottieDrawable.setMaxFrame(endFrame);
+  }
+
+  /**
+   * Sets the maximum progress that the animation will end at when playing or looping.
+   */
+  public void setMaxProgress(float endProgress) {
+    lottieDrawable.setMaxProgress(endProgress);
+  }
+
+  /**
+   * @see #setMinFrame(int)
+   * @see #setMaxFrame(int)
+   */
+  public void setMinAndMaxFrame(int minFrame, int maxFrame) {
+    lottieDrawable.setMinAndMaxFrame(minFrame, maxFrame);
+  }
+
+  /**
+   * @see #setMinProgress(float)
+   * @see #setMaxProgress(float)
+   */
+  public void setMinAndMaxProgress(float minProgress, float maxProgress) {
+    lottieDrawable.setMinAndMaxProgress(minProgress, maxProgress);
+  }
+
+  /**
+   * Reverses the current animation speed. This does NOT play the animation.
+   */
+  public void reverseAnimationSpeed() {
+    lottieDrawable.reverseAnimationSpeed();
+  }
+
+  /**
+   * Sets the playback speed. If speed < 0, the animation will play backwards.
+   */
+  public void setSpeed(float speed) {
+    lottieDrawable.setSpeed(speed);
+  }
+
+  /**
+   * Returns the current playback speed. This will be < 0 if the animation is playing backwards.
+   */
+  public float getSpeed() {
+    return lottieDrawable.getSpeed();
+  }
+
   public void addAnimatorUpdateListener(ValueAnimator.AnimatorUpdateListener updateListener) {
     lottieDrawable.addAnimatorUpdateListener(updateListener);
   }
@@ -437,63 +520,6 @@ import java.util.Map;
 
   public boolean isAnimating() {
     return lottieDrawable.isAnimating();
-  }
-
-  public void playAnimation() {
-    lottieDrawable.playAnimation();
-    enableOrDisableHardwareLayer();
-  }
-
-  public void resumeAnimation() {
-    lottieDrawable.resumeAnimation();
-    enableOrDisableHardwareLayer();
-  }
-
-  public void playAnimation(final int startFrame, final int endFrame) {
-    lottieDrawable.playAnimation(startFrame, endFrame);
-  }
-
-  public void playAnimation(@FloatRange(from = 0f, to = 1f) float startProgress,
-      @FloatRange(from = 0f, to = 1f) float endProgress) {
-    lottieDrawable.playAnimation(startProgress, endProgress);
-  }
-
-  public void reverseAnimation() {
-    lottieDrawable.reverseAnimation();
-    enableOrDisableHardwareLayer();
-  }
-
-  public void setMinFrame(int startFrame) {
-    lottieDrawable.setMinFrame(startFrame);
-  }
-
-  public void setMinProgress(float startProgress) {
-    lottieDrawable.setMinProgress(startProgress);
-  }
-
-  public void setMaxFrame(int endFrame) {
-    lottieDrawable.setMaxFrame(endFrame);
-  }
-
-  public void setMaxProgress(float endProgress) {
-    lottieDrawable.setMaxProgress(endProgress);
-  }
-
-  public void setMinAndMaxFrame(int minFrame, int maxFrame) {
-    lottieDrawable.setMinAndMaxFrame(minFrame, maxFrame);
-  }
-
-  public void setMinAndMaxProgress(float minProgress, float maxProgress) {
-    lottieDrawable.setMinAndMaxProgress(minProgress, maxProgress);
-  }
-
-  public void resumeReverseAnimation() {
-    lottieDrawable.resumeReverseAnimation();
-    enableOrDisableHardwareLayer();
-  }
-
-  public void setSpeed(float speed) {
-    lottieDrawable.setSpeed(speed);
   }
 
   /**
@@ -575,9 +601,7 @@ import java.util.Map;
   }
 
   public void pauseAnimation() {
-    float progress = getProgress();
-    lottieDrawable.cancelAnimation();
-    setProgress(progress);
+    lottieDrawable.pauseAnimation();
     enableOrDisableHardwareLayer();
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -479,6 +479,9 @@ import java.util.Map;
 
   /**
    * Reverses the current animation speed. This does NOT play the animation.
+   * @see #setSpeed(float)
+   * @see #playAnimation()
+   * @see #resumeAnimation()
    */
   public void reverseAnimationSpeed() {
     lottieDrawable.reverseAnimationSpeed();

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -457,7 +457,7 @@ import java.util.Map;
   /**
    * Sets the maximum progress that the animation will end at when playing or looping.
    */
-  public void setMaxProgress(float endProgress) {
+  public void setMaxProgress(@FloatRange(from = 0f, to = 1f) float endProgress) {
     lottieDrawable.setMaxProgress(endProgress);
   }
 
@@ -473,7 +473,9 @@ import java.util.Map;
    * @see #setMinProgress(float)
    * @see #setMaxProgress(float)
    */
-  public void setMinAndMaxProgress(float minProgress, float maxProgress) {
+  public void setMinAndMaxProgress(
+      @FloatRange(from = 0f, to = 1f) float minProgress,
+      @FloatRange(from = 0f, to = 1f) float maxProgress) {
     lottieDrawable.setMinAndMaxProgress(minProgress, maxProgress);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -444,6 +444,9 @@ import java.util.Set;
 
   /**
    * Reverses the current animation speed. This does NOT play the animation.
+   * @see #setSpeed(float)
+   * @see #playAnimation()
+   * @see #resumeAnimation()
    */
   public void reverseAnimationSpeed() {
     animator.reverseAnimationSpeed();

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -420,7 +420,7 @@ import java.util.Set;
   /**
    * Sets the maximum progress that the animation will end at when playing or looping.
    */
-  public void setMaxProgress(float maxProgress) {
+  public void setMaxProgress(@FloatRange(from = 0f, to = 1f) float maxProgress) {
     animator.setMaxValue(maxProgress);
   }
 
@@ -437,7 +437,9 @@ import java.util.Set;
    * @see #setMinProgress(float)
    * @see #setMaxProgress(float)
    */
-  public void setMinAndMaxProgress(float minProgress, float maxProgress) {
+  public void setMinAndMaxProgress(
+      @FloatRange(from = 0f, to = 1f) float minProgress,
+      @FloatRange(from = 0f, to = 1f) float maxProgress) {
     setMinProgress(minProgress);
     setMaxProgress(maxProgress);
   }
@@ -584,6 +586,7 @@ import java.util.Set;
     animator.pauseAnimation();
   }
 
+  @FloatRange(from = 0f, to = 1f)
   public float getProgress() {
     return animator.getValue();
   }

--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -1,6 +1,7 @@
 package com.airbnb.lottie.utils;
 
 import android.animation.ValueAnimator;
+import android.support.annotation.FloatRange;
 
 /**
  * This is a slightly modified {@link ValueAnimator} that allows us to update start and end values
@@ -9,11 +10,10 @@ import android.animation.ValueAnimator;
 public class LottieValueAnimator extends ValueAnimator {
   private boolean systemAnimationsAreDisabled = false;
   private long compositionDuration;
-  private float minValue = 0f;
-  private float maxValue = 1f;
   private float speed = 1f;
-
-  private float value = 0f;
+  @FloatRange(from = 0f, to = 1f) private float value = 0f;
+  @FloatRange(from = 0f, to = 1f) private float minValue = 0f;
+  @FloatRange(from = 0f, to = 1f) private float maxValue = 1f;
 
   public LottieValueAnimator() {
     setInterpolator(null);
@@ -38,7 +38,12 @@ public class LottieValueAnimator extends ValueAnimator {
     updateValues();
   }
 
-  public void setValue(float value) {
+  /**
+   * Sets the current animator value. This will update the play time as well.
+   * It will also be clamped to the values set with {@link #setMinValue(float)} and
+   * {@link #setMaxValue(float)}.
+   */
+  public void setValue(@FloatRange(from = 0f, to = 1f) float value) {
     value = MiscUtils.clamp(value, minValue, maxValue);
 
     this.value = value;
@@ -54,7 +59,7 @@ public class LottieValueAnimator extends ValueAnimator {
     return value;
   }
 
-  public void setMinValue(float minValue) {
+  public void setMinValue(@FloatRange(from = 0f, to = 1f) float minValue) {
     if (minValue >= maxValue) {
       throw new IllegalArgumentException("Min value must be smaller then max value.");
     }
@@ -62,7 +67,7 @@ public class LottieValueAnimator extends ValueAnimator {
     updateValues();
   }
 
-  public void setMaxValue(float maxValue) {
+  public void setMaxValue(@FloatRange(from = 0f, to = 1f) float maxValue) {
     if (maxValue <= minValue) {
       throw new IllegalArgumentException("Max value must be greater than min value.");
     }
@@ -109,6 +114,10 @@ public class LottieValueAnimator extends ValueAnimator {
     return speed < 0;
   }
 
+  /**
+   * Update the float values of the animator, scales the duration for the current min/max range
+   * and updates the play time so that it matches the new min/max range.
+   */
   private void updateValues() {
     setDuration((long) (compositionDuration * (maxValue - minValue) / Math.abs(speed)));
     setFloatValues(

--- a/lottie/src/test/java/com/airbnb/lottie/LottieValueAnimatorUnitTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/LottieValueAnimatorUnitTest.java
@@ -1,0 +1,104 @@
+package com.airbnb.lottie;
+
+import com.airbnb.lottie.utils.LottieValueAnimator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
+public class LottieValueAnimatorUnitTest {
+
+  private LottieValueAnimator animator;
+
+  @Before
+  public void setup() {
+    animator = new LottieValueAnimator();
+    animator.setCompositionDuration(1000);
+  }
+
+  @Test
+  public void testInitialState() {
+    assertEquals(0f, animator.getValue());
+  }
+
+  @Test
+    public void testResumingMaintainsValue() {
+    animator.setValue(0.5f);
+    animator.resumeAnimation();
+    assertEquals(0.5f, animator.getValue());
+  }
+
+  @Test
+    public void testPlayingResetsValue() {
+    animator.setValue(0.5f);
+    animator.playAnimation();
+    assertEquals(0f, animator.getValue());
+    assertEquals(0f, animator.getAnimatedFraction());
+  }
+
+  @Test
+  public void testReversingMaintainsValue() {
+    animator.setValue(0.25f);
+    animator.reverseAnimationSpeed();
+    assertEquals(0.25f, animator.getValue());
+    assertEquals(0.75f, animator.getAnimatedFraction());
+  }
+
+  @Test
+    public void testReversingWithMinValueMaintainsValue() {
+    animator.setMinValue(0.1f);
+    animator.setValue(1f);
+    animator.reverseAnimationSpeed();
+    assertEquals(1f, animator.getValue());
+    assertEquals(0f, animator.getAnimatedFraction());
+  }
+
+  @Test
+  public void testReversingWithMaxValueMaintainsValue() {
+    animator.setMaxValue(0.9f);
+    animator.reverseAnimationSpeed();
+    assertEquals(0f, animator.getValue());
+    assertEquals(1f, animator.getAnimatedFraction());
+  }
+
+  @Test
+  public void testResumeReversingWithMinValueMaintainsValue() {
+    animator.setMaxValue(0.9f);
+    animator.reverseAnimationSpeed();
+    animator.resumeAnimation();
+    assertEquals(0.9f, animator.getValue());
+    assertEquals(0f, animator.getAnimatedFraction());
+  }
+
+  @Test
+  public void testPlayReversingWithMinValueMaintainsValue() {
+    animator.setMaxValue(0.9f);
+    animator.reverseAnimationSpeed();
+    animator.playAnimation();
+    assertEquals(0.9f, animator.getValue());
+    assertEquals(0f, animator.getAnimatedFraction());
+  }
+
+  @Test
+  public void testMinAndMaxBothSet() {
+    animator.setMinValue(0.2f);
+    animator.setMaxValue(0.8f);
+    animator.setValue(0.4f);
+    assertEquals(0.33f, animator.getAnimatedFraction(), 0.01);
+    animator.reverseAnimationSpeed();
+    assertEquals(0.4f, animator.getValue(), 0.01);
+    assertEquals(0.66f, animator.getAnimatedFraction(), 0.01);
+    animator.resumeAnimation();
+    assertEquals(0.4f, animator.getValue(), 0.01);
+    assertEquals(0.66f, animator.getAnimatedFraction(), 0.01);
+    animator.playAnimation();
+    assertEquals(0.8f, animator.getValue());
+    assertEquals(0f, animator.getAnimatedFraction());
+  }
+}


### PR DESCRIPTION
This is the second major LottieValueAnimator overhaul. The first one wound up being overly complex and didn't work great. This cleans up the logic and adds a bunch of unit tests.

This is a breaking change because it removes some confusing APIs such as `resumeReverseAnimation`. You now just set a negative speed and call `resumeAnimation`

Fixes #492 
Fixes #483 