### PR TITLE
make lottie drawable implement animatable

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -9,6 +9,7 @@ import android.graphics.ColorFilter;
 import android.graphics.Matrix;
 import android.graphics.PixelFormat;
 import android.graphics.Typeface;
+import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.FloatRange;
@@ -45,7 +46,8 @@ import java.util.Set;
  * handles bitmap recycling and asynchronous loading
  * of compositions.
  */
-@SuppressWarnings({"WeakerAccess", "unused"}) public class LottieDrawable extends Drawable implements Drawable.Callback {
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class LottieDrawable extends Drawable implements Drawable.Callback, Animatable {
   private static final String TAG = LottieDrawable.class.getSimpleName();
 
   private interface LazyCompositionTask {
@@ -302,6 +304,19 @@ import java.util.Set;
   }
 
 // <editor-fold desc="animator">
+
+  @Override public void start() {
+    playAnimation();
+  }
+
+  @Override public void stop() {
+    lazyCompositionTasks.clear();
+    animator.end();
+  }
+
+  @Override public boolean isRunning() {
+    return isAnimating();
+  }
 
   /**
    * Plays the animation from the beginning. If speed is < 0, it will start at the end

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -310,8 +310,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   }
 
   @Override public void stop() {
-    lazyCompositionTasks.clear();
-    animator.end();
+    endAnimation();
   }
 
   @Override public boolean isRunning() {
@@ -332,6 +331,11 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       return;
     }
     animator.playAnimation();
+  }
+
+  public void endAnimation() {
+    lazyCompositionTasks.clear();
+    animator.endAnimation();
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -105,6 +105,10 @@ public class LottieValueAnimator extends ValueAnimator {
     setValue(isReversed() ? maxValue : minValue);
   }
 
+  public void endAnimation() {
+    end();
+  }
+
   public void pauseAnimation() {
     float value = this.value;
     cancel();


### PR DESCRIPTION
This pull request updates `LottieDrawable` to implement the `Animatable` interface. See #579.

The implementation behaves the same as it does for `AnimatedVectorDrawable`s: https://github.com/aosp-mirror/platform_frameworks_base/blob/oreo-mr1-release/graphics/java/android/graphics/drawable/AnimatedVectorDrawable.java#L893-L945

TLDR:
* `start()` calls `playAnimation()`
* `stop()` calls `animator.end()`
* `isRunning()` calls `isAnimating()`