### PR TITLE
Fix min bodymoving version check.

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
@@ -51,22 +51,15 @@ public class LottieComposition {
   private float startFrame;
   private float endFrame;
   private float frameRate;
-  /* Bodymovin version */
-  private int majorVersion;
-  private int minorVersion;
-  private int patchVersion;
 
-  public void init(Rect bounds, float startFrame, float endFrame, float frameRate, int majorVersion,
-      int minorVersion, int patchVersion, List<Layer> layers, LongSparseArray<Layer> layerMap,
-      Map<String, List<Layer>> precomps, Map<String, LottieImageAsset> images,
+  public void init(Rect bounds, float startFrame, float endFrame, float frameRate,
+      List<Layer> layers, LongSparseArray<Layer> layerMap, Map<String,
+      List<Layer>> precomps, Map<String, LottieImageAsset> images,
       SparseArrayCompat<FontCharacter> characters, Map<String, Font> fonts) {
     this.bounds = bounds;
     this.startFrame = startFrame;
     this.endFrame = endFrame;
     this.frameRate = frameRate;
-    this.majorVersion = majorVersion;
-    this.minorVersion = minorVersion;
-    this.patchVersion = patchVersion;
     this.layers = layers;
     this.layerMap = layerMap;
     this.precomps = precomps;
@@ -105,21 +98,6 @@ public class LottieComposition {
   @SuppressWarnings("WeakerAccess") public float getDuration() {
     float frameDuration = endFrame - startFrame;
     return (long) (frameDuration / frameRate * 1000);
-  }
-
-  @RestrictTo(RestrictTo.Scope.LIBRARY)
-  public int getMajorVersion() {
-    return majorVersion;
-  }
-
-  @RestrictTo(RestrictTo.Scope.LIBRARY)
-  public int getMinorVersion() {
-    return minorVersion;
-  }
-
-  @RestrictTo(RestrictTo.Scope.LIBRARY)
-  public int getPatchVersion() {
-    return patchVersion;
   }
 
   @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/lottie/src/main/java/com/airbnb/lottie/parser/LottieCompositionParser.java
+++ b/lottie/src/main/java/com/airbnb/lottie/parser/LottieCompositionParser.java
@@ -28,9 +28,6 @@ public class LottieCompositionParser {
     float startFrame = 0f;
     float endFrame = 0f;
     float frameRate = 0f;
-    int majorVersion = 0;
-    int minorVersion = 0;
-    int patchVersion = 0;
     final LongSparseArray<Layer> layerMap = new LongSparseArray<>();
     final List<Layer> layers = new ArrayList<>();
     int width = 0;
@@ -63,10 +60,11 @@ public class LottieCompositionParser {
         case "v":
           String version = reader.nextString();
           String[] versions = version.split("\\.");
-          majorVersion = Integer.parseInt(versions[0]);
-          minorVersion = Integer.parseInt(versions[1]);
-          patchVersion = Integer.parseInt(versions[2]);
-          if (!Utils.isAtLeastVersion(composition, 4, 5, 0)) {
+          int majorVersion = Integer.parseInt(versions[0]);
+          int minorVersion = Integer.parseInt(versions[1]);
+          int patchVersion = Integer.parseInt(versions[2]);
+          if (!Utils.isAtLeastVersion(majorVersion, minorVersion, patchVersion,
+              4, 5, 0)) {
             composition.addWarning("Lottie only supports bodymovin >= 4.5.0");
           }
           break;
@@ -92,8 +90,8 @@ public class LottieCompositionParser {
     int scaledHeight = (int) (height * scale);
     Rect bounds = new Rect(0, 0, scaledWidth, scaledHeight);
 
-    composition.init(bounds, startFrame, endFrame, frameRate, majorVersion, minorVersion,
-        patchVersion, layers, layerMap, precomps, images, characters, fonts);
+    composition.init(bounds, startFrame, endFrame, frameRate, layers, layerMap, precomps,
+        images, characters, fonts);
 
     return composition;
   }

--- a/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
@@ -12,7 +12,6 @@ import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
 
 import com.airbnb.lottie.L;
-import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.animation.content.TrimPathContent;
 
 import java.io.Closeable;
@@ -152,21 +151,21 @@ public final class Utils {
   }
 
   @SuppressWarnings("SameParameterValue")
-  public static boolean isAtLeastVersion(LottieComposition composition, int major, int minor, int
-      patch) {
-    if (composition.getMajorVersion() < major) {
+  public static boolean isAtLeastVersion(int major, int minor, int patch, int minMajor, int minMinor, int
+      minPatch) {
+    if (major < minMajor) {
       return false;
-    } else if (composition.getMajorVersion() > major) {
+    } else if (major > minMajor) {
       return true;
     }
 
-    if (composition.getMinorVersion() < minor) {
+    if (minor < minMinor) {
       return false;
-    } else if (composition.getMinorVersion() > minor) {
+    } else if (minor > minMinor) {
       return true;
     }
 
-    return composition.getPatchVersion() >= patch;
+    return patch >= minPatch;
   }
 
   public static int hashFor(float a, float b, float c, float d) {


### PR DESCRIPTION
In order for Utils.isAtLeastVersion to work, the init method needs to be called before it, but it was not. This removes the unnecessary variables that were being stored without need. Since they were restricted to the library and only being used there, I removed them.