### PR TITLE
rename confusing words, remove duplicate in gradle dependency

### DIFF
--- a/LottieSample/src/main/res/layout/activity_test_color_filter.xml
+++ b/LottieSample/src/main/res/layout/activity_test_color_filter.xml
@@ -12,7 +12,7 @@
         android:layout_height="50dp"
         android:background="#ffffff"
         app:lottie_colorFilter="#ffff00"
-        app:lottie_fileName="HamburgerArrow.json"/>
+        app:lottie_setAnimation="HamburgerArrow.json"/>
 
 
     <com.airbnb.lottie.LottieAnimationView
@@ -21,6 +21,6 @@
         android:layout_height="50dp"
         android:background="#ffffff"
         app:lottie_colorFilter="@null"
-        app:lottie_fileName="HamburgerArrow.json"/>
+        app:lottie_setAnimation="HamburgerArrow.json"/>
 
 </LinearLayout>

--- a/LottieSample/src/main/res/layout/fragment_dynamic.xml
+++ b/LottieSample/src/main/res/layout/fragment_dynamic.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        airbnb:lottie_fileName="AndroidWave.json"
+        airbnb:lottie_setAnimation="AndroidWave.json"
         airbnb:lottie_autoPlay="true"
         airbnb:lottie_loop="true"/>
     <Button

--- a/LottieSample/src/main/res/layout/fragment_font.xml
+++ b/LottieSample/src/main/res/layout/fragment_font.xml
@@ -16,7 +16,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginRight="16dp"
-            app:lottie_fileName="Name.json"
+            app:lottie_setAnimation="Name.json"
             app:lottie_autoPlay="true"
             app:lottie_loop="true"/>
 
@@ -24,7 +24,7 @@
             android:id="@+id/dynamic_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:lottie_fileName="Name.json"
+            app:lottie_setAnimation="Name.json"
             app:lottie_autoPlay="true"
             app:lottie_loop="true"/>
     </LinearLayout>

--- a/LottieSample/src/main/res/layout/fragment_list.xml
+++ b/LottieSample/src/main/res/layout/fragment_list.xml
@@ -16,7 +16,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            app:lottie_fileName="Logo/LogoSmall.json"
+            app:lottie_setAnimation="Logo/LogoSmall.json"
             app:lottie_loop="true" />
     </FrameLayout>
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ buildscript {
     classpath 'com.android.tools.build:gradle:3.0.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
-    classpath 'org.ajoberstar:grgit:1.9.3'
   }
 }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -41,7 +41,7 @@ import java.util.Map;
  * bodymovin (https://github.com/bodymovin/bodymovin).
  * <p>
  * You may set the animation in one of two ways:
- * 1) Attrs: {@link R.styleable#LottieAnimationView_lottie_fileName}
+ * 1) Attrs: {@link R.styleable#LottieAnimationView_lottie_setAnimation}
  * 2) Programatically: {@link #setAnimation(String)}, {@link #setComposition(LottieComposition)},
  * or {@link #setAnimation(JSONObject)}.
  * <p>
@@ -116,9 +116,9 @@ import java.util.Map;
     defaultCacheStrategy = CacheStrategy.values()[cacheStrategy];
     if (!isInEditMode()) {
       boolean hasRawRes = ta.hasValue(R.styleable.LottieAnimationView_lottie_rawRes);
-      boolean hasFileName = ta.hasValue(R.styleable.LottieAnimationView_lottie_fileName);
+      boolean hasFileName = ta.hasValue(R.styleable.LottieAnimationView_lottie_setAnimation);
       if (hasRawRes && hasFileName) {
-        throw new IllegalArgumentException("lottie_rawRes and lottie_fileName cannot be used at " +
+        throw new IllegalArgumentException("lottie_rawRes and lottie_setAnimation cannot be used at " +
             "the same time. Please use use only one at once.");
       } else if (hasRawRes) {
         int rawResId = ta.getResourceId(R.styleable.LottieAnimationView_lottie_rawRes, 0);
@@ -126,7 +126,7 @@ import java.util.Map;
           setAnimation(rawResId);
         }
       } else if (hasFileName) {
-        String fileName = ta.getString(R.styleable.LottieAnimationView_lottie_fileName);
+        String fileName = ta.getString(R.styleable.LottieAnimationView_lottie_setAnimation);
         if (fileName != null) {
           setAnimation(fileName);
         }

--- a/lottie/src/main/res/values/attrs.xml
+++ b/lottie/src/main/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="LottieAnimationView">
-        <attr name="lottie_fileName" format="string" />
+        <attr name="lottie_setAnimation" format="string" />
         <attr name="lottie_rawRes" format="reference" />
         <attr name="lottie_autoPlay" format="boolean" />
         <attr name="lottie_loop" format="boolean" />


### PR DESCRIPTION
### 1. changed duplicated gradle depencency.

```
  dependencies {
    classpath 'org.ajoberstar:grgit:1.9.3'
    classpath 'com.android.tools.build:gradle:3.0.1'
    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
    classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
    classpath 'org.ajoberstar:grgit:1.9.3' // removed
  }
```

### 2. rename confusing words.

The `lottie_filename` in xml and` .setAnimation () `in java are the same function. 
But their names are so different.
Many people(include me!), will get confused every time they use this.
So, I changed name `lottie_filename` to `lottie_setAnimation`.

Now, we can use it like below. (looks very uniform !)
```xml
    <com.airbnb.lottie.LottieAnimationView
        android:id="@+id/yellow_color_filter"
        android:layout_width="50dp"
        android:layout_height="50dp"
        android:background="#ffffff"
        app:lottie_colorFilter="#ffff00"
        app:lottie_setAnimation="HamburgerArrow.json"/>
```

```java
LottieAnimationView animationView = (LottieAnimationView) findViewById(R.id.animation_view);
animationView.setAnimation("hello-world.json");
animationView.loop(true);
animationView.playAnimation();
```