### PR TITLE
Clear the composition when a new one is set

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -353,7 +353,7 @@ import java.util.Map;
       return;
     }
 
-    lottieDrawable.cancelAnimation();
+    clearComposition();
     cancelLoaderTask();
     compositionLoader = LottieComposition.Factory.fromRawFile(getContext(), animationResId,
         new OnCompositionLoadedListener() {
@@ -402,7 +402,7 @@ import java.util.Map;
       return;
     }
 
-    lottieDrawable.cancelAnimation();
+    clearComposition();
     cancelLoaderTask();
     compositionLoader = LottieComposition.Factory.fromAssetFileName(getContext(), animationName,
         new OnCompositionLoadedListener() {
@@ -447,6 +447,7 @@ import java.util.Map;
    * bodymovin json from the network and pass it directly here.
    */
   public void setAnimation(JsonReader reader) {
+    clearComposition();
     cancelLoaderTask();
     compositionLoader = LottieComposition.Factory.fromJsonReader(reader, loadedListener);
   }
@@ -823,6 +824,11 @@ import java.util.Map;
   @Nullable
   public PerformanceTracker getPerformanceTracker() {
     return lottieDrawable.getPerformanceTracker();
+  }
+
+  private void clearComposition() {
+    composition = null;
+    lottieDrawable.clearComposition();
   }
 
   private void enableOrDisableHardwareLayer() {


### PR DESCRIPTION
Before this, if a composition was loaded async after an existing composition was set, calls to LottieAnimationView would still be called on the old animation because it was still set as the active animation. This clears the existing one while a new one is being loaded so that new calls get added to the lazy composition tasks queue.

@phoca this will fix your issue in #287