### PR TITLE
Get version name from gradle.properties

### DIFF
--- a/lottie/build.gradle
+++ b/lottie/build.gradle
@@ -10,7 +10,7 @@ android {
     minSdkVersion 16
     targetSdkVersion 27
     versionCode 100
-    versionName "2.5.0-rc2"
+    versionName project.ext.properties.get("VERSION_NAME")
   }
   lintOptions {
     abortOnError true


### PR DESCRIPTION
As titled. When doing future releases, there should now be one place less to update the `versionName` attribute because `build.gradle` will now fetch the attribute directly from `gradle.properties`.

If there's a better way of doing this, I'm all ears.

Tests are green:

![lottie-tests](https://user-images.githubusercontent.com/1175953/36245023-3317af7c-1229-11e8-9091-a2e19dc70c46.png)
