### PR TITLE
Fix LottieValueAnimator when LottieComposition has a non-zero startFrame

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -211,7 +211,7 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
     if (composition == null) {
       return 0;
     }
-    return minFrame == Integer.MIN_VALUE ? 0 : minFrame;
+    return minFrame == Integer.MIN_VALUE ? composition.getStartFrame() : minFrame;
   }
 
   private float getMaxFrame() {


### PR DESCRIPTION
Fixes #656 
`getMinFrame()` will return `composition.getStartFrame()` if minFrame has not been set. This mimics how `getMaxFrame()` returns `composition.getEndFrame()` if maxFrame has not been set.