### PR TITLE
Render every frame instead of matching AE fps

### DIFF
--- a/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/PlayerFragment.kt
+++ b/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/PlayerFragment.kt
@@ -363,6 +363,7 @@ class PlayerFragment : Fragment() {
         warningsContainer.removeAllViews()
         updateWarnings()
 
+        // Scale up to fill the screen
         scaleSeekBar.progress = 100
     }
 

--- a/lottie/src/main/res/values/ids.xml
+++ b/lottie/src/main/res/values/ids.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="lottie_layer_name" type="id" />
-    <item name="rc_file" type="id" />
 </resources>


### PR DESCRIPTION
As of 2.5.0, Lottie would try and match the framerate specified in After Effects. This ends up just making things look janky most of the time. This reverts that to the old behavior of rendering every frame.

Fixes #647 