### PR TITLE
Update the drawable when the composition is reset to the same one

### DIFF
--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/LottieSnapshotProvider.java
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/LottieSnapshotProvider.java
@@ -7,6 +7,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.PointF;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Environment;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -484,7 +485,7 @@ public class LottieSnapshotProvider extends SnapshotProvider {
     LottieComposition composition = LottieComposition.Factory.fromFileSync(context, "Tests/Shapes.json");
     LottieAnimationView view = new LottieAnimationView(context);
     view.setComposition(composition);
-    view.setImageResource(R.drawable.ic_assets);
+    view.setImageDrawable(new ColorDrawable(Color.RED));
     view.setComposition(composition);
     ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(
         ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);

--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/LottieSnapshotProvider.java
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/LottieSnapshotProvider.java
@@ -71,6 +71,7 @@ public class LottieSnapshotProvider extends SnapshotProvider {
     testFrameBoundary2();
     testScaleTypes();
     testDynamicProperties();
+    testSwitchingToDrawableAndBack();
   }
 
   private void snapshotAssets(String[] animations) {
@@ -477,6 +478,17 @@ public class LottieSnapshotProvider extends SnapshotProvider {
         ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
     animationView.addValueCallback(keyPath, property, callback);
     recordSnapshot(animationView, 1080, "android", "Dynamic Properties", name, params);
+  }
+
+  private void testSwitchingToDrawableAndBack() {
+    LottieComposition composition = LottieComposition.Factory.fromFileSync(context, "Tests/Shapes.json");
+    LottieAnimationView view = new LottieAnimationView(context);
+    view.setComposition(composition);
+    view.setImageResource(R.drawable.ic_assets);
+    view.setComposition(composition);
+    ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    recordSnapshot(view, 1080, "android", "Reset Animation", "Drawable and back", params);
   }
 
   private int dpToPx(int dp) {

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -480,9 +480,10 @@ import java.util.Map;
     }
     lottieDrawable.setCallback(this);
 
+    this.composition = composition;
     boolean isNewComposition = lottieDrawable.setComposition(composition);
     enableOrDisableHardwareLayer();
-    if (!isNewComposition) {
+    if (getDrawable() == lottieDrawable && !isNewComposition) {
       // We can avoid re-setting the drawable, and invalidating the view, since the composition
       // hasn't changed.
       return;
@@ -492,8 +493,6 @@ import java.util.Map;
     // the drawable is different than the original.
     setImageDrawable(null);
     setImageDrawable(lottieDrawable);
-
-    this.composition = composition;
 
     requestLayout();
   }


### PR DESCRIPTION
Previously, if you set an animation, switched to a drawable, and switched back to *the same* animation, LottieDrawable would report that the composition was the same and it would not update the drawable on LottieAnimationView.

Thanks for catching this @sin3hz
Fixes #648 