### PR TITLE
Fix race condition with min/max frame

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -121,7 +121,11 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
 
   public void setComposition(LottieComposition composition) {
     this.composition = composition;
-    setMinAndMaxFrames((int) composition.getStartFrame(), (int) composition.getEndFrame());
+
+    setMinAndMaxFrames(
+        (int) Math.max(this.minFrame, composition.getStartFrame()),
+        (int) Math.min(this.maxFrame, composition.getEndFrame())
+    );
     setFrame((int) frame);
     lastFrameTimeNs = System.nanoTime();
   }


### PR DESCRIPTION
Composition can be loaded after we have set a custom `minFrame` and/or `maxFrame`.
The composition will override custom values.