### PR TITLE
Use lerp calculation to get the min and max frame.

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -449,10 +449,9 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       });
       return;
     }
-    setMinAndMaxFrame(
-        (int) (minProgress * composition.getDurationFrames()),
-        (int) (maxProgress * composition.getDurationFrames())
-    );
+
+    setMinAndMaxFrame((int) MiscUtils.lerp(composition.getStartFrame(), composition.getEndFrame(), minProgress),
+                      (int) MiscUtils.lerp(composition.getStartFrame(), composition.getEndFrame(), maxProgress));
   }
 
   /**

--- a/lottie/src/test/java/com/airbnb/lottie/LottieDrawableTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/LottieDrawableTest.java
@@ -35,11 +35,11 @@ public class LottieDrawableTest {
 
   @Test
   public void testMinFrame() {
-    LottieComposition composition = createComposition(0, 200);
+    LottieComposition composition = createComposition(31, 391);
     LottieDrawable drawable = new LottieDrawable();
     drawable.setComposition(composition);
-    drawable.setMinProgress(0.5f);
-    assertEquals(100f, drawable.getMinFrame());
+    drawable.setMinProgress(0.42f);
+    assertEquals(182f, drawable.getMinFrame());
   }
 
   @Test
@@ -53,10 +53,20 @@ public class LottieDrawableTest {
 
   @Test
   public void testMaxFrame() {
-    LottieComposition composition = createComposition(0, 200);
+    LottieComposition composition = createComposition(31, 391);
     LottieDrawable drawable = new LottieDrawable();
     drawable.setComposition(composition);
-    drawable.setMaxProgress(0.5f);
-    assertEquals(100f, drawable.getMaxFrame());
+    drawable.setMaxProgress(0.25f);
+    assertEquals(121f, drawable.getMaxFrame());
+  }
+
+  @Test
+  public void testMinMaxFrame() {
+    LottieComposition composition = createComposition(31, 391);
+    LottieDrawable drawable = new LottieDrawable();
+    drawable.setComposition(composition);
+    drawable.setMinAndMaxProgress(0.25f, 0.42f);
+    assertEquals(121f, drawable.getMinFrame());
+    assertEquals(182f, drawable.getMaxFrame());
   }
 }


### PR DESCRIPTION
Fixes #763

Added test for bug in LottieDrawableTest. Fixed tests for `setMinProgress` and `setMaxProgress` since the tests would pass if the with the broken method of calculating frame.

For example, given progress of 0.5, endFrame of 200, and startFrame of 0
`0.5 * (200 - 0) == 0 + (0.5 * (200 - 0))`

whereas given progress of 0.5, endFrame of 200, and startFrame of 20
`0.5 * (200 - 20) = 90`
`20 + (0.5 * (200 - 20) = 110`