### PR TITLE
Fixed danglign choreographer callback.

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -23,7 +23,7 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
   private float minFrame = Integer.MIN_VALUE;
   private float maxFrame = Integer.MAX_VALUE;
   @Nullable private LottieComposition composition;
-  @VisibleForTesting protected boolean isRunning = false;
+  @VisibleForTesting protected boolean running = false;
 
   public LottieValueAnimator() {
   }
@@ -72,7 +72,7 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
   }
 
   @Override public boolean isRunning() {
-    return isRunning;
+    return running;
   }
 
   @Override public void doFrame(long frameTimeNanos) {
@@ -193,6 +193,7 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
   }
 
   public void playAnimation() {
+    running = true;
     notifyStart(isReversed());
     setFrame((int) (isReversed() ? getMaxFrame() : getMinFrame()));
     lastFrameTimeNs = System.nanoTime();
@@ -210,6 +211,7 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
   }
 
   public void resumeAnimation() {
+    running = true;
     postFrameCallback();
     lastFrameTimeNs = System.nanoTime();
     if (isReversed() && getFrame() == getMinFrame()) {
@@ -243,14 +245,21 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
   }
 
   protected void postFrameCallback() {
-    removeFrameCallback();
-    Choreographer.getInstance().postFrameCallback(this);
-    isRunning = true;
+    if (isRunning()) {
+      removeFrameCallback(false);
+      Choreographer.getInstance().postFrameCallback(this);
+    }
   }
 
   protected void removeFrameCallback() {
+    this.removeFrameCallback(true);
+  }
+
+  protected void removeFrameCallback(boolean stopRunning) {
     Choreographer.getInstance().removeFrameCallback(this);
-    isRunning = false;
+    if (stopRunning) {
+      running = false;
+    }
   }
 
   private void verifyFrame() {

--- a/lottie/src/test/java/com/airbnb/lottie/LottieValueAnimatorUnitTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/LottieValueAnimatorUnitTest.java
@@ -55,11 +55,11 @@ public class LottieValueAnimatorUnitTest {
     // Choreographer#postFrameCallback hangs with robolectric.
     return new LottieValueAnimator() {
       @Override public void postFrameCallback() {
-        isRunning = true;
+        running = true;
       }
 
       @Override public void removeFrameCallback() {
-        isRunning = false;
+        running = false;
       }
     };
   }


### PR DESCRIPTION
**This patch fixes the performance issue.**

I've seen the cases where the previous version of the code was re-adding callbacks to the choreographer in case of cancelation/pause. Now it is designed to make it impossible. It looks like there is a copy of the callbacks stored somewhere in the stack. I've been able to reproduce the problem on Android 6.0 and 7.0.

This issue caused application performance degradation and battery drain in the background for us.