### PR TITLE
Change repositories order to fix gradle sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
 
 allprojects {
   repositories {
-    jcenter()
     google()
+    jcenter()
     maven {
       url "https://jitpack.io"
     }


### PR DESCRIPTION
Fixed the issue [stackoverflow](https://stackoverflow.com/questions/50570134/could-not-find-common-jar-android-arch-corecommon1-1-0)