### PR TITLE
Fix setMinAndMaxFrames

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -162,7 +162,7 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
   }
 
   public void setMinAndMaxFrames(int minFrame, int maxFrame) {
-    float compositionMinFrame = composition == null ? Float.MIN_VALUE : composition.getStartFrame();
+    float compositionMinFrame = composition == null ? -Float.MAX_VALUE : composition.getStartFrame();
     float compositionMaxFrame = composition == null ? Float.MAX_VALUE : composition.getEndFrame();
     this.minFrame = MiscUtils.clamp(minFrame, compositionMinFrame, compositionMaxFrame);
     this.maxFrame = MiscUtils.clamp(maxFrame, compositionMinFrame, compositionMaxFrame);


### PR DESCRIPTION
`public void setMinAndMaxFrames(int minFrame, int maxFrame)` started to behave strange when I updated. So I debug it. I found something very (very) strange.

If `composition` is `null`, `compositionMinFrame` will be set to `Float.MIN_VALUE`.  
And if I pass to the function `minFrame = 0` then... (attach your belt...)

`MiscUtils.clamp(minFrame, compositionMinFrame, compositionMaxFrame)`
=> `MiscUtils.clamp(0, Float.MIN_VALUE, Float.MAX_VALUE)`
**give `1.4E-45` (ouch!)**

... I don't know exactly why but `(Float.MIN_VALUE >= 0) == true`!
It's probably because the float are cast to `int`.

Anyway, elsewhere we use `Integer.MIN_VALUE` and `Integer.MAX_VALUE` for `this.minFrame` and `this.maxFrame` 👍 

![capture](https://user-images.githubusercontent.com/4509277/41907319-c4ede3d4-7940-11e8-8065-720ca83f52fa.PNG)
