### PR TITLE
Fix ImageLayer.java may use a recycled bitmap 

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
@@ -30,7 +30,7 @@ public class ImageLayer extends BaseLayer {
 
   @Override public void drawLayer(@NonNull Canvas canvas, Matrix parentMatrix, int parentAlpha) {
     Bitmap bitmap = getBitmap();
-    if (bitmap == null) {
+    if (bitmap == null || bitmap.isRecycled()) {
       return;
     }
     float density = Utils.dpScale();


### PR DESCRIPTION
Use a recycled bitmap may produce a crash

![image](https://user-images.githubusercontent.com/9399699/42365246-802dda90-8130-11e8-9aa6-9fde1515056e.png)
