### PR TITLE
CompositionLayer: Handle invalid Region.Op on Android Pie

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
@@ -3,6 +3,7 @@ package com.airbnb.lottie.model.layer;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.RectF;
+import android.os.Build;
 import android.support.annotation.FloatRange;
 import android.support.annotation.Nullable;
 import android.support.v4.util.LongSparseArray;
@@ -93,7 +94,11 @@ public class CompositionLayer extends BaseLayer {
     for (int i = layers.size() - 1; i >= 0 ; i--) {
       boolean nonEmptyClip = true;
       if (!newClipRect.isEmpty()) {
-        nonEmptyClip = canvas.clipRect(newClipRect);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            nonEmptyClip = canvas.clipOutRect(newClipRect);
+        } else {
+            nonEmptyClip = canvas.clipRect(newClipRect);
+        }
       }
       if (nonEmptyClip) {
         BaseLayer layer = layers.get(i);


### PR DESCRIPTION
* clipRect is deprecated with a Region.Op other than Region.Op.INTERSECT and Region.Op.DIFFERENCE

Signed-off-by: Brandon McAnsh <bmcansh@powerley.com>