### PR TITLE
Fix recycle asset bitmap improperly

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -118,14 +118,13 @@ public class ImageAssetManager {
 
   public void recycleBitmaps() {
     synchronized (bitmapHashLock) {
-      Iterator<Map.Entry<String, LottieImageAsset>> it = imageAssets.entrySet().iterator();
-      while (it.hasNext()) {
-        Map.Entry<String, LottieImageAsset> entry = it.next();
-        Bitmap bitmap = entry.getValue().getBitmap();
+      for (Map.Entry<String, LottieImageAsset> entry : imageAssets.entrySet()) {
+        LottieImageAsset asset = entry.getValue();
+        Bitmap bitmap = asset.getBitmap();
         if (bitmap != null) {
           bitmap.recycle();
+          asset.setBitmap(null);
         }
-        it.remove();
       }
     }
   }


### PR DESCRIPTION
Reproduce step:
1. Open a Lottie animation with external image reference, for example: `assets/Tests/WeAccept.json`
2. Close animation by press back button
3. Reopen same Lottie animation, the animation doesn't display.

For more details of this problem, please reference: https://github.com/cdotchen/lottie-android/pull/1