### PR TITLE
LottieCompositionFactory and Caching Cleanup

### DIFF
--- a/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/LottieFontViewGroup.kt
+++ b/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/LottieFontViewGroup.kt
@@ -19,7 +19,6 @@ import java.util.*
 class LottieFontViewGroup @JvmOverloads constructor(
         context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
-    private val compositionMap = HashMap<String, LottieComposition>()
     private val views = ArrayList<View>()
 
     private val cursorView: LottieAnimationView by lazy { LottieAnimationView(context) }
@@ -149,15 +148,8 @@ class LottieFontViewGroup @JvmOverloads constructor(
         //         break;
         // }
         val fileName = "Mobilo/$letter.json"
-        if (compositionMap.containsKey(fileName)) {
-            addComposition(compositionMap[fileName]!!)
-        } else {
-            LottieCompositionFactory.fromAsset(context, fileName)
-                    .addListener {
-                        compositionMap.put(fileName, it)
-                        addComposition(it)
-                    }
-        }
+        LottieCompositionFactory.fromAsset(context, fileName)
+                .addListener { addComposition(it) }
 
         return true
     }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieTask.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieTask.java
@@ -121,7 +121,7 @@ public class LottieTask<T> {
    * a listener if neccesary.
    * @return the task for call chaining.
    */
-  public synchronized LottieTask<T> removeFailureListener(LottieListener<T> listener) {
+  public synchronized LottieTask<T> removeFailureListener(LottieListener<Throwable> listener) {
     failureListeners.remove(listener);
     stopTaskObserverIfNeeded();
     return this;

--- a/lottie/src/main/java/com/airbnb/lottie/model/LottieCompositionCache.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/LottieCompositionCache.java
@@ -1,18 +1,11 @@
 package com.airbnb.lottie.model;
 
-import android.content.res.Resources;
 import android.support.annotation.Nullable;
-import android.support.annotation.RawRes;
 import android.support.annotation.RestrictTo;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.util.LruCache;
 
-import com.airbnb.lottie.LottieAnimationView.CacheStrategy;
 import com.airbnb.lottie.LottieComposition;
-
-import java.lang.ref.WeakReference;
-import java.util.HashMap;
-import java.util.Map;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class LottieCompositionCache {
@@ -31,23 +24,16 @@ public class LottieCompositionCache {
   }
 
   @Nullable
-  public LottieComposition getRawRes(@RawRes int rawRes) {
-    return get(Integer.toString(rawRes));
+  public LottieComposition get(@Nullable String cacheKey) {
+    if (cacheKey == null) {
+      return null;
+    }
+    return cache.get(cacheKey);
   }
 
-  @Nullable
-  public LottieComposition get(String assetName) {
-    return cache.get(assetName);
-  }
-
-  public void put(@RawRes int rawRes, @Nullable LottieComposition composition) {
-    put(Integer.toString(rawRes), composition);
-  }
-
-  public void put(@Nullable String cacheKey, @Nullable LottieComposition composition) {
+  public void put(@Nullable String cacheKey, LottieComposition composition) {
     if (cacheKey == null) {
       return;
-
     }
     cache.put(cacheKey, composition);
   }

--- a/lottie/src/main/res/values/attrs.xml
+++ b/lottie/src/main/res/values/attrs.xml
@@ -14,11 +14,6 @@
         <attr name="lottie_imageAssetsFolder" format="string" />
         <attr name="lottie_progress" format="float" />
         <attr name="lottie_enableMergePathsForKitKatAndAbove" format="boolean" />
-        <attr name="lottie_cacheStrategy" format="enum">
-            <enum name="none" value="0" />
-            <enum name="weak" value="1" />
-            <enum name="strong" value="2" />
-        </attr>
         <attr name="lottie_colorFilter" format="color" />
         <attr name="lottie_scale" format="float" />
     </declare-styleable>

--- a/lottie/src/test/java/com/airbnb/lottie/model/LottieCompositionCacheTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/model/LottieCompositionCacheTest.java
@@ -30,7 +30,6 @@ public class LottieCompositionCacheTest {
   @Test
   public void testEmpty() {
     assertNull(cache.get("foo"));
-    assertNull(cache.getRawRes(123));
   }
 
   @Test
@@ -43,23 +42,5 @@ public class LottieCompositionCacheTest {
   public void testWeakAsset() {
     cache.put("foo", composition);
     assertEquals(composition, cache.get("foo"));
-  }
-
-  @Test
-  public void testStrongRawRes() {
-    cache.put(123, composition);
-    assertEquals(composition, cache.getRawRes(123));
-  }
-
-  @Test
-  public void testWeakRawRes() {
-    cache.put(123, composition);
-    assertEquals(composition, cache.getRawRes(123));
-  }
-
-  @Test
-  public void testStringAndWeakRawRes() {
-    cache.put(123, composition);
-    assertEquals(composition, cache.getRawRes(123));
   }
 }


### PR DESCRIPTION
This cleans up a number of things related to the LottieCompositionFactory.
It:
* Handled task caching at the LottieCompositionFactory level so it is guaranteed to work everywhere. The existing architecture left several instances where compositions would not be cached.
* Simplified the way tasks are handled in `LottieAnimationView`
* Fixes #958 in which different cache keys are used for rawRes animations
* Removed deprecated factory APIs
