### PR TITLE
Don't allow minFrame > maxFrame in LottieValueAnimator

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -163,6 +163,9 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
   }
 
   public void setMinAndMaxFrames(int minFrame, int maxFrame) {
+    if (minFrame > maxFrame) {
+      throw new IllegalArgumentException(String.format("minFrame (%s) must be <= maxFrame (%s)", minFrame, maxFrame));
+    }
     float compositionMinFrame = composition == null ? -Float.MAX_VALUE : composition.getStartFrame();
     float compositionMaxFrame = composition == null ? Float.MAX_VALUE : composition.getEndFrame();
     this.minFrame = MiscUtils.clamp(minFrame, compositionMinFrame, compositionMaxFrame);

--- a/lottie/src/test/java/com/airbnb/lottie/LottieValueAnimatorUnitTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/LottieValueAnimatorUnitTest.java
@@ -164,6 +164,23 @@ public class LottieValueAnimatorUnitTest extends BaseTest {
   }
 
   @Test
+  public void testSetFrameIntegrity() {
+    animator.setMinAndMaxFrames(200, 800);
+
+    // setFrame < minFrame should clamp to minFrame
+    animator.setFrame(100);
+    assertEquals(200, animator.getFrame());
+
+    animator.setFrame(900);
+    assertEquals(800, animator.getFrame());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMinAndMaxFrameIntegrity() {
+    animator.setMinAndMaxFrames(800, 200);
+  }
+
+  @Test
   public void testDefaultAnimator() {
     testAnimator(new VerifyListener() {
       @Override public void verify(InOrder inOrder) {


### PR DESCRIPTION
I tracked this back as the root cause of this error:

```
Fatal Exception: java.lang.IllegalStateException: Frame must be [117,000000,19,000000]. It is 19,000000
       at com.airbnb.lottie.utils.LottieValueAnimator.verifyFrame(LottieValueAnimator.java:270)
       at com.airbnb.lottie.utils.LottieValueAnimator.doFrame(LottieValueAnimator.java:114)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:979)
...
```