### PR TITLE
Fixed the bug of ImageAssetManager.updateBitmap not return the expect…

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -61,7 +61,9 @@ public class ImageAssetManager {
       asset.setBitmap(null);
       return ret;
     }
-    return putBitmap(id, bitmap);
+    Bitmap prevBitmap = imageAssets.get(id).getBitmap();
+    putBitmap(id, bitmap);
+    return prevBitmap;
   }
 
   @Nullable public Bitmap bitmapForId(String id) {


### PR DESCRIPTION
As the implement of ImageAssetManager.putBitmap had changed, the ImageAssetManager.updateBitmap currently not return the expect result as its comment said.

Change-Id: Icd78af15a5c82b9b58270ade8906dd971d2738ad
Signed-off-by: dongshangyong <dongshangyong@bytedance.com>