### PR TITLE
Added memory cache layer for async network requests

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -52,8 +52,13 @@ public class LottieCompositionFactory {
    * future use. Because of this, you may call `fromUrl` ahead of time to warm the cache if you think you
    * might need an animation in the future.
    */
-  public static LottieTask<LottieComposition> fromUrl(Context context, String url) {
-    return NetworkFetcher.fetch(context, url);
+  public static LottieTask<LottieComposition> fromUrl(final Context context, final String url) {
+    String urlCacheKey = "url_" + url;
+    return cache(urlCacheKey, new Callable<LottieResult<LottieComposition>>() {
+      @Override public LottieResult<LottieComposition> call() {
+        return NetworkFetcher.fetchSync(context, url);
+      }
+    });
   }
 
   /**
@@ -318,7 +323,7 @@ public class LottieCompositionFactory {
   /**
    * First, check to see if there are any in-progress tasks associated with the cache key and return it if there is.
    * If not, create a new task for the callable.
-   * Then, add the new task to the task cache and set up listeners to it gets cleared when done.
+   * Then, add the new task to the task cache and set up listeners so it gets cleared when done.
    */
   private static LottieTask<LottieComposition> cache(
           @Nullable final String cacheKey, Callable<LottieResult<LottieComposition>> callable) {

--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
@@ -9,7 +9,6 @@ import com.airbnb.lottie.L;
 import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieCompositionFactory;
 import com.airbnb.lottie.LottieResult;
-import com.airbnb.lottie.LottieTask;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -19,7 +18,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.concurrent.Callable;
 import java.util.zip.ZipInputStream;
 
 public class NetworkFetcher {
@@ -29,10 +27,6 @@ public class NetworkFetcher {
 
   private final NetworkCache networkCache;
 
-  public static LottieTask<LottieComposition> fetch(Context context, String url) {
-    return new NetworkFetcher(context, url).fetch();
-  }
-
   public static LottieResult<LottieComposition> fetchSync(Context context, String url) {
     return new NetworkFetcher(context, url).fetchSync();
   }
@@ -41,14 +35,6 @@ public class NetworkFetcher {
     appContext = context.getApplicationContext();
     this.url = url;
     networkCache = new NetworkCache(appContext, url);
-  }
-
-  private LottieTask<LottieComposition> fetch() {
-    return new LottieTask<>(new Callable<LottieResult<LottieComposition>>() {
-      @Override public LottieResult<LottieComposition> call() throws Exception {
-        return fetchSync();
-      }
-    });
   }
 
   @WorkerThread


### PR DESCRIPTION
Added a call to the LRU Memory cache for lottie network requests.

I've also removed the asyncFetch calls from the NetworkFetcher since the url lottie composition creates an Async task from the LRU cache call