### PR TITLE
Annotate fetchBitmap as @Nullable

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/ImageAssetDelegate.java
+++ b/lottie/src/main/java/com/airbnb/lottie/ImageAssetDelegate.java
@@ -1,6 +1,7 @@
 package com.airbnb.lottie;
 
 import android.graphics.Bitmap;
+import androidx.annotation.Nullable;
 
 /**
  * Delegate to handle the loading of bitmaps that are not packaged in the assets of your app.
@@ -8,5 +9,5 @@ import android.graphics.Bitmap;
  * @see LottieDrawable#setImageAssetDelegate(ImageAssetDelegate)
  */
 public interface ImageAssetDelegate {
-  Bitmap fetchBitmap(LottieImageAsset asset);
+  @Nullable Bitmap fetchBitmap(LottieImageAsset asset);
 }


### PR DESCRIPTION
According to the example in https://airbnb.io/lottie/android/images.html#providing-your-own-images, fetchBitmap() can return null and Lottie will keep asking until a non-null Bitmap is returned.