### PR TITLE
[Breaking Change] Automatic hardware acceleration detection

### DIFF
--- a/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/PlayerFragment.kt
+++ b/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/PlayerFragment.kt
@@ -181,12 +181,6 @@ class PlayerFragment : BaseMvRxFragment() {
             trimContainer.animateVisible(it)
         }
 
-        hardwareAccelerationToggle.setOnClickListener { viewModel.toggleHardwareAcceleration() }
-        viewModel.selectSubscribe(PlayerState::useHardwareAcceleration) {
-            hardwareAccelerationToggle.isActivated = it
-            animationView.useHardwareAcceleration(it)
-        }
-
         mergePathsToggle.setOnClickListener { viewModel.toggleMergePaths() }
         viewModel.selectSubscribe(PlayerState::useMergePaths) {
             animationView.enableMergePathsForKitKatAndAbove(it)
@@ -411,6 +405,7 @@ class PlayerFragment : BaseMvRxFragment() {
         composition ?: return
 
         animationView.setComposition(composition)
+        hardwareAccelerationToggle.isActivated = animationView.layerType == View.LAYER_TYPE_HARDWARE
         animationView.setPerformanceTrackingEnabled(true)
         var renderTimeGraphRange = 4f
         animationView.performanceTracker?.addFrameListener { ms ->

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -8,6 +8,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.FloatRange;
@@ -15,7 +16,6 @@ import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RawRes;
-import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.widget.AppCompatImageView;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -73,7 +73,6 @@ import java.util.Set;
   private @RawRes int animationResId;
   private boolean wasAnimatingWhenDetached = false;
   private boolean autoPlay = false;
-  private boolean useHardwareLayer = false;
   private Set<LottieOnCompositionLoadedListener> lottieOnCompositionLoadedListeners = new HashSet<>();
 
   @Nullable private LottieTask<LottieComposition> compositionTask;
@@ -259,54 +258,6 @@ import java.util.Set;
    */
   public boolean isMergePathsEnabledForKitKatAndAbove() {
     return lottieDrawable.isMergePathsEnabledForKitKatAndAbove();
-  }
-
-  /**
-   * @see #useHardwareAcceleration(boolean)
-   */
-  @Deprecated
-  public void useExperimentalHardwareAcceleration() {
-    useHardwareAcceleration(true);
-  }
-
-
-  /**
-   * @see #useHardwareAcceleration(boolean)
-   */
-  @Deprecated
-  public void useExperimentalHardwareAcceleration(boolean use) {
-    useHardwareAcceleration(use);
-  }
-
-  /**
-   * @see #useHardwareAcceleration(boolean)
-   */
-  public void useHardwareAcceleration() {
-    useHardwareAcceleration(true);
-  }
-
-  /**
-   * Enable hardware acceleration for this view.
-   * READ THIS BEFORE ENABLING HARDWARE ACCELERATION:
-   * 1) Test your animation on the minimum API level you support. Some drawing features such as
-   *    dashes and stroke caps have min api levels
-   *    (https://developer.android.com/guide/topics/graphics/hardware-accel.html#unsupported)
-   * 2) Enabling hardware acceleration is not always more performant. Check it with your specific
-   *    animation only if you are having performance issues with software rendering.
-   * 3) Software rendering is safer and will be consistent across devices. Manufacturers can
-   *    potentially break hardware rendering with bugs in their SKIA engine. Lottie cannot do
-   *    anything about that.
-   */
-  public void useHardwareAcceleration(boolean use) {
-    if (useHardwareLayer == use) {
-      return;
-    }
-    useHardwareLayer = use;
-    enableOrDisableHardwareLayer();
-  }
-
-  public boolean getUseHardwareAcceleration() {
-    return useHardwareLayer;
   }
 
   /**
@@ -794,7 +745,10 @@ import java.util.Set;
   }
 
   private void enableOrDisableHardwareLayer() {
-    boolean useHardwareLayer = this.useHardwareLayer && lottieDrawable.isAnimating();
+    boolean useHardwareLayer = true;
+    if (composition != null && composition.hasDashPattern() && Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+      useHardwareLayer = false;
+    }
     setLayerType(useHardwareLayer ? LAYER_TYPE_HARDWARE : LAYER_TYPE_SOFTWARE, null);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
@@ -51,7 +51,12 @@ public class LottieComposition {
   private float startFrame;
   private float endFrame;
   private float frameRate;
+  /**
+   * Used to determine if an animation can be drawn with hardware acceleration.
+   */
+  private boolean hasDashPattern;
 
+  @RestrictTo(RestrictTo.Scope.LIBRARY)
   public void init(Rect bounds, float startFrame, float endFrame, float frameRate,
       List<Layer> layers, LongSparseArray<Layer> layerMap, Map<String,
       List<Layer>> precomps, Map<String, LottieImageAsset> images,
@@ -72,6 +77,18 @@ public class LottieComposition {
   public void addWarning(String warning) {
     Log.w(L.TAG, warning);
     warnings.add(warning);
+  }
+
+  @RestrictTo(RestrictTo.Scope.LIBRARY)
+  public void setHasDashPattern(boolean hasDashPattern) {
+    this.hasDashPattern = hasDashPattern;
+  }
+
+  /**
+   * Used to determine if an animation can be drawn with hardware acceleration.
+   */
+  public boolean hasDashPattern() {
+    return hasDashPattern;
   }
 
   public ArrayList<String> getWarnings() {

--- a/lottie/src/main/java/com/airbnb/lottie/parser/GradientStrokeParser.java
+++ b/lottie/src/main/java/com/airbnb/lottie/parser/GradientStrokeParser.java
@@ -109,6 +109,7 @@ class GradientStrokeParser {
             if (n.equals("o")) {
               offset = val;
             } else if (n.equals("d") || n.equals("g")) {
+              composition.setHasDashPattern(true);
               lineDashPattern.add(val);
             }
           }

--- a/lottie/src/main/java/com/airbnb/lottie/parser/ShapeStrokeParser.java
+++ b/lottie/src/main/java/com/airbnb/lottie/parser/ShapeStrokeParser.java
@@ -83,6 +83,7 @@ class ShapeStrokeParser {
                 break;
               case "d":
               case "g":
+                composition.setHasDashPattern(true);
                 lineDashPattern.add(val);
                 break;
             }


### PR DESCRIPTION
Dash path effects are the only feature that Lottie uses that isn't supported on all api levels. We should be able to safely detect this [one case for API < 28](https://developer.android.com/guide/topics/graphics/hardware-accel#unsupported) and turn on hardware acceleration otherwise.

This removes the existing APIs since they no longer have a function.