### PR TITLE
Add renderMode to control automatic/software/hardware acceleration

### DIFF
--- a/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/PlayerFragment.kt
+++ b/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/PlayerFragment.kt
@@ -19,6 +19,7 @@ import androidx.transition.TransitionManager
 import com.airbnb.lottie.L
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieComposition
+import com.airbnb.lottie.RenderMode
 import com.airbnb.lottie.model.KeyPath
 import com.airbnb.lottie.samples.model.CompositionArgs
 import com.airbnb.lottie.samples.views.BackgroundColorView
@@ -146,6 +147,16 @@ class PlayerFragment : BaseMvRxFragment() {
                     else R.drawable.ic_border_off
             )
             animationView.setBackgroundResource(if (it) R.drawable.outline else 0)
+        }
+
+        hardwareAccelerationToggle.setOnClickListener {
+            val renderMode = if (animationView.layerType == View.LAYER_TYPE_HARDWARE) {
+                RenderMode.Software
+            } else {
+                RenderMode.Hardware
+            }
+            animationView.setRenderMode(renderMode)
+            hardwareAccelerationToggle.isActivated = animationView.layerType == View.LAYER_TYPE_HARDWARE
         }
 
         viewModel.selectSubscribe(PlayerState::controlsVisible) { controlsContainer.animateVisible(it) }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
@@ -55,6 +55,12 @@ public class LottieComposition {
    * Used to determine if an animation can be drawn with hardware acceleration.
    */
   private boolean hasDashPattern;
+  /**
+   * Counts the number of mattes and masks. Before Android switched to SKIA
+   * for drawing in Oreo (API 28), using hardware acceleration with mattes and masks
+   * was only faster until you had ~4 masks after which it would actually become slower.
+   */
+  private int maskAndMatteCount = 0;
 
   @RestrictTo(RestrictTo.Scope.LIBRARY)
   public void init(Rect bounds, float startFrame, float endFrame, float frameRate,
@@ -84,11 +90,25 @@ public class LottieComposition {
     this.hasDashPattern = hasDashPattern;
   }
 
+  @RestrictTo(RestrictTo.Scope.LIBRARY)
+  public void incrementMatteOrMaskCount(int amount) {
+    maskAndMatteCount += amount;
+  }
+
   /**
    * Used to determine if an animation can be drawn with hardware acceleration.
    */
+  @RestrictTo(RestrictTo.Scope.LIBRARY)
   public boolean hasDashPattern() {
     return hasDashPattern;
+  }
+
+  /**
+   * Used to determine if an animation can be drawn with hardware acceleration.
+   */
+  @RestrictTo(RestrictTo.Scope.LIBRARY)
+  public int getMaskAndMatteCount() {
+    return maskAndMatteCount;
   }
 
   public ArrayList<String> getWarnings() {

--- a/lottie/src/main/java/com/airbnb/lottie/RenderMode.java
+++ b/lottie/src/main/java/com/airbnb/lottie/RenderMode.java
@@ -1,0 +1,13 @@
+package com.airbnb.lottie;
+
+/**
+ * Controls how Lottie should render.
+ * Defaults to {@link RenderMode#Automatic}.
+ *
+ * @see LottieAnimationView#setRenderMode(RenderMode) for more information.
+ */
+public enum RenderMode {
+    Automatic,
+    Hardware,
+    Software
+}

--- a/lottie/src/main/java/com/airbnb/lottie/parser/LayerParser.java
+++ b/lottie/src/main/java/com/airbnb/lottie/parser/LayerParser.java
@@ -100,12 +100,14 @@ public class LayerParser {
           break;
         case "tt":
           matteType = Layer.MatteType.values()[reader.nextInt()];
+          composition.incrementMatteOrMaskCount(1);
           break;
         case "masksProperties":
           reader.beginArray();
           while (reader.hasNext()) {
             masks.add(MaskParser.parse(reader, composition));
           }
+          composition.incrementMatteOrMaskCount(masks.size());
           reader.endArray();
           break;
         case "shapes":

--- a/lottie/src/main/res/values/attrs.xml
+++ b/lottie/src/main/res/values/attrs.xml
@@ -17,5 +17,11 @@
         <attr name="lottie_colorFilter" format="color" />
         <attr name="lottie_scale" format="float" />
         <attr name="lottie_speed" format="float" />
+        <!-- These values must be kept in sync with the RenderMode enum -->
+        <attr name="lottie_renderMode" format="enum">
+            <enum name="automatic" value="0" />
+            <enum name="hardware" value="1" />
+            <enum name="software" value="2" />
+        </attr>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
While testing, I discovered that animations with lots of/large masks and mattes perform *significantly* worse with hardware acceleration than software acceleration on pre-Pie devices because of RenderNode#textureUpload. It is really hard to detect this dynamically so I'm leaving the default on automatic (with an additional heuristic for >4 mattes and masks) but having an option to set it to hardware/software manually.

#381 