### PR TITLE
Fix null cacheKeys Returning Cached Tasks

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -327,7 +327,7 @@ public class LottieCompositionFactory {
    */
   private static LottieTask<LottieComposition> cache(
           @Nullable final String cacheKey, Callable<LottieResult<LottieComposition>> callable) {
-    final LottieComposition cachedComposition = LottieCompositionCache.getInstance().get(cacheKey);
+    final LottieComposition cachedComposition = cacheKey == null ? null : LottieCompositionCache.getInstance().get(cacheKey);
     if (cachedComposition != null) {
       return new LottieTask<>(new Callable<LottieResult<LottieComposition>>() {
         @Override
@@ -336,7 +336,7 @@ public class LottieCompositionFactory {
         }
       });
     }
-    if (taskCache.containsKey(cacheKey)) {
+    if (cacheKey != null && taskCache.containsKey(cacheKey)) {
       return taskCache.get(cacheKey);
     }
 

--- a/lottie/src/test/java/com/airbnb/lottie/LottieCompositionFactoryTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/LottieCompositionFactoryTest.java
@@ -16,6 +16,7 @@ import java.io.FileNotFoundException;
 import java.io.StringReader;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 
@@ -79,5 +80,21 @@ public class LottieCompositionFactoryTest extends BaseTest {
     LottieResult<LottieComposition> result = LottieCompositionFactory.fromRawResSync(RuntimeEnvironment.application, 0);
     assertNotNull(result.getException());
     assertNull(result.getValue());
+  }
+
+  @Test
+  public void testNullMultipleTimesAsync() {
+    JsonReader reader = new JsonReader(new StringReader(JSON));
+    LottieTask<LottieComposition> task1 = LottieCompositionFactory.fromJsonReader(reader, null);
+    LottieTask<LottieComposition> task2 = LottieCompositionFactory.fromJsonReader(reader, null);
+    assertFalse(task1 == task2);
+  }
+
+  @Test
+  public void testNullMultipleTimesSync() {
+    JsonReader reader = new JsonReader(new StringReader(JSON));
+    LottieResult<LottieComposition> task1 = LottieCompositionFactory.fromJsonReaderSync(reader, null);
+    LottieResult<LottieComposition> task2 = LottieCompositionFactory.fromJsonReaderSync(reader, null);
+    assertFalse(task1 == task2);
   }
 }


### PR DESCRIPTION
Previously, setting a null cache key could return a cached task or result. This explicitly prevents that from happening. The new tests failed before and pass now.
Fixes #1092 