### PR TITLE
Pause Lottie when visibility changes

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -21,6 +21,7 @@ import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.JsonReader;
 import android.util.Log;
+import android.view.View;
 
 import com.airbnb.lottie.model.KeyPath;
 import com.airbnb.lottie.value.LottieFrameInfo;
@@ -71,6 +72,7 @@ import java.util.Set;
   private final LottieDrawable lottieDrawable = new LottieDrawable();
   private String animationName;
   private @RawRes int animationResId;
+  private boolean wasAnimatingWhenVisibilityChanged = false;
   private boolean wasAnimatingWhenDetached = false;
   private boolean autoPlay = false;
   private RenderMode renderMode = RenderMode.Automatic;
@@ -226,6 +228,20 @@ import java.util.Set;
     lottieDrawable.setImagesAssetsFolder(ss.imageAssetsFolder);
     setRepeatMode(ss.repeatMode);
     setRepeatCount(ss.repeatCount);
+  }
+
+  @Override
+  protected void onVisibilityChanged(@NonNull View changedView, int visibility) {
+    if (visibility == VISIBLE && wasAnimatingWhenVisibilityChanged) {
+      resumeAnimation();
+    } else {
+      if (isAnimating()) {
+        wasAnimatingWhenVisibilityChanged = true;
+        pauseAnimation();
+      } else {
+        wasAnimatingWhenVisibilityChanged = false;
+      }
+    }
   }
 
   @Override protected void onAttachedToWindow() {


### PR DESCRIPTION
onAttachedToWindow and onDetachedFromWindow aren't sufficient for LottieAnimationView to properly pause and resume. We must do the same from onVisibilityChanged as well or we risk Lottie animating when the app is in the background.

Fixes #987 
Thanks @florianPOLARSTEPS