### PR TITLE
Fix animations starting paused when autoPlay is set to true

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -232,14 +232,14 @@ import java.util.Set;
 
   @Override
   protected void onVisibilityChanged(@NonNull View changedView, int visibility) {
-    if (visibility == VISIBLE && wasAnimatingWhenVisibilityChanged) {
-      resumeAnimation();
+    if (visibility == VISIBLE) {
+      if (wasAnimatingWhenVisibilityChanged) {
+        resumeAnimation();
+      }
     } else {
+      wasAnimatingWhenVisibilityChanged = isAnimating();
       if (isAnimating()) {
-        wasAnimatingWhenVisibilityChanged = true;
         pauseAnimation();
-      } else {
-        wasAnimatingWhenVisibilityChanged = false;
       }
     }
   }


### PR DESCRIPTION
The assumed logic for the original code was that the `else` branch is for `visibility != VISIBLE` but that isn't true if `visibility == VISIBLE` and wasAnimatingWhenVisibilityChanged is false. That caused animations to incorrectly be paused the first time they became visible when autoPlay was true.

Fixes #1123 