### PR TITLE
Prevent setMaxFrame from truncating the last frame.

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -450,7 +450,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       });
       return;
     }
-    animator.setMaxFrame(maxFrame);
+    animator.setMaxFrame(maxFrame + 0.99f);
   }
 
   /**
@@ -555,7 +555,8 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       });
       return;
     }
-    animator.setMinAndMaxFrames(minFrame, maxFrame);
+    // Adding 0.99 ensures that the maxFrame itself gets played.
+    animator.setMinAndMaxFrames(minFrame, maxFrame + 0.99f);
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -159,11 +159,11 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
     setMinAndMaxFrames(minFrame, (int) maxFrame);
   }
 
-  public void setMaxFrame(int maxFrame) {
-    setMinAndMaxFrames((int) minFrame, maxFrame);
+  public void setMaxFrame(float maxFrame) {
+    setMinAndMaxFrames(minFrame, maxFrame);
   }
 
-  public void setMinAndMaxFrames(int minFrame, int maxFrame) {
+  public void setMinAndMaxFrames(float minFrame, float maxFrame) {
     if (minFrame > maxFrame) {
       throw new IllegalArgumentException(String.format("minFrame (%s) must be <= maxFrame (%s)", minFrame, maxFrame));
     }

--- a/lottie/src/test/java/com/airbnb/lottie/LottieDrawableTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/LottieDrawableTest.java
@@ -51,7 +51,7 @@ public class LottieDrawableTest extends BaseTest {
     LottieDrawable drawable = new LottieDrawable();
     drawable.setComposition(composition);
     drawable.setMaxProgress(0.25f);
-    assertEquals(121f, drawable.getMaxFrame());
+    assertEquals(121.99f, drawable.getMaxFrame());
   }
 
   @Test
@@ -61,6 +61,6 @@ public class LottieDrawableTest extends BaseTest {
     drawable.setComposition(composition);
     drawable.setMinAndMaxProgress(0.25f, 0.42f);
     assertEquals(121f, drawable.getMinFrame());
-    assertEquals(182f, drawable.getMaxFrame());
+    assertEquals(182.99f, drawable.getMaxFrame());
   }
 }


### PR DESCRIPTION
Lottie should render the max frame. However, setting the max frame truncated it to an int so the frame itself would never render.
I can confirm that this fixes #1034. Calling `getProgress()` from `onAninmationEnd()` yielded 0.996 before and 1.0 now. The animation attached in #1034 also fully disappears by the end of the animation.