### PR TITLE
Match trailing carriage returns and ignore case for marker names

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
@@ -181,7 +181,7 @@ public class LottieComposition {
     int size = markers.size();
     for (int i = 0; i < markers.size(); i++) {
       Marker marker = markers.get(i);
-      if (markerName.equals(marker.name)) {
+      if (marker.matchesName(markerName)) {
         return marker;
       }
     }

--- a/lottie/src/main/java/com/airbnb/lottie/model/Marker.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/Marker.java
@@ -1,8 +1,9 @@
 package com.airbnb.lottie.model;
 
 public class Marker {
+  private static String CARRIAGE_RETURN = "\r";
 
-  public final String name;
+  private final String name;
   public final float startFrame;
   public final float durationFrames;
 
@@ -10,5 +11,18 @@ public class Marker {
     this.name = name;
     this.durationFrames = durationFrames;
     this.startFrame = startFrame;
+  }
+
+  public boolean matchesName(String name) {
+    if (this.name.equalsIgnoreCase(name)) {
+      return true;
+    }
+
+    // It is easy for a designer to accidentally include an extra newline which will cause the name to not match what they would
+    // expect. This is a convenience to precent unneccesary confusion.
+    if (this.name.endsWith(CARRIAGE_RETURN) && this.name.substring(0, this.name.length() - 1).equalsIgnoreCase(name)) {
+      return true;
+    }
+    return false;
   }
 }

--- a/lottie/src/test/java/com/airbnb/lottie/model/MarkerTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/model/MarkerTest.java
@@ -1,0 +1,14 @@
+package com.airbnb.lottie.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MarkerTest {
+
+  @Test
+  public void testMarkerWithCarriageReturn() {
+    Marker marker = new Marker("Foo\r", 0f, 0f);
+    assertTrue(marker.matchesName("foo"));
+  }
+}


### PR DESCRIPTION
Fixes #1163 