### PR TITLE
Fix issues about visibility changes

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -72,7 +72,7 @@ import java.util.Set;
   private final LottieDrawable lottieDrawable = new LottieDrawable();
   private String animationName;
   private @RawRes int animationResId;
-  private boolean wasAnimatingWhenVisibilityChanged = false;
+  private boolean wasAnimatingWhenNotShown = false;
   private boolean wasAnimatingWhenDetached = false;
   private boolean autoPlay = false;
   private RenderMode renderMode = RenderMode.AUTOMATIC;
@@ -238,14 +238,15 @@ import java.util.Set;
     if (lottieDrawable == null) {
       return;
     }
-    if (visibility == VISIBLE) {
-      if (wasAnimatingWhenVisibilityChanged) {
+    if (isShown()) {
+      if (wasAnimatingWhenNotShown) {
         resumeAnimation();
+        wasAnimatingWhenNotShown = false;
       }
     } else {
-      wasAnimatingWhenVisibilityChanged = isAnimating();
       if (isAnimating()) {
         pauseAnimation();
+        wasAnimatingWhenNotShown = true;
       }
     }
   }
@@ -411,8 +412,12 @@ import java.util.Set;
    */
   @MainThread
   public void playAnimation() {
-    lottieDrawable.playAnimation();
-    enableOrDisableHardwareLayer();
+    if (isShown()) {
+      lottieDrawable.playAnimation();
+      enableOrDisableHardwareLayer();
+    } else {
+      wasAnimatingWhenNotShown = true;
+    }
   }
 
   /**
@@ -421,8 +426,12 @@ import java.util.Set;
    */
   @MainThread
   public void resumeAnimation() {
-    lottieDrawable.resumeAnimation();
-    enableOrDisableHardwareLayer();
+    if (isShown()) {
+      lottieDrawable.resumeAnimation();
+      enableOrDisableHardwareLayer();
+    } else {
+      wasAnimatingWhenNotShown = true;
+    }
   }
 
   /**
@@ -740,12 +749,14 @@ import java.util.Set;
 
   @MainThread
   public void cancelAnimation() {
+    wasAnimatingWhenNotShown = false;
     lottieDrawable.cancelAnimation();
     enableOrDisableHardwareLayer();
   }
 
   @MainThread
   public void pauseAnimation() {
+    wasAnimatingWhenNotShown = false;
     lottieDrawable.pauseAnimation();
     enableOrDisableHardwareLayer();
   }


### PR DESCRIPTION
#### 1) The animation could be resumed although it is not visible.
`onVisibilityChanged` callback will be called even when the visibilities of the ancestors of the view has changed.
So we need to check the visibility with `isShown()`, not with `visibility == View.VISIBLE` in onVisibilityChanged callback.
https://developer.android.com/reference/android/view/View#isShown()

**ex)** Assume below view hierarchy when the activity is in background.
DecorView (invisible)
...
|- FrameLayout (invisible)
|- |- LottieAnimationView (visible)

When the activity goes foreground, onVisibilityChanged callback in LottieAnimationView will be called by DecorView's visibility changing.
```java
onVisibilityChanged(DecorView /* changedView */, true /* visibility */)
```
Then, LottieAnimationView will resume animation although it is not visible by FrameLayout.
DecorView (visible)
.. 
|- FrameLayout (invisible)
|- |- LottieAnimationView (visible)

#### 2) `playAnimation()` and `resumeAnimation()` could be called while not visible.
`playAnimation()` and `resumeAnimation()` should be blocked if the view is not visible,
and the animation should be resumed when the view goes visible.
So, we need to set `wasAnimatingWhenNotShown = true` in `playAnimation()` and `resumeAnimation()` when the view is not visible.

#### 3) `pauseAnimation()` and `cancelAnimation()` were not worked when the activity is in background.
The animation could be resumed by `onVisibilityChanged` callback.
We need to reset `wasAnimatingWhenNotShown = false` in `pauseAnimation()` and `cancelAnimation()`