### PR TITLE
No animation if systemAnimationScale == 0

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -24,6 +24,7 @@ import android.util.Log;
 import android.view.View;
 
 import com.airbnb.lottie.model.KeyPath;
+import com.airbnb.lottie.utils.Utils;
 import com.airbnb.lottie.value.LottieFrameInfo;
 import com.airbnb.lottie.value.LottieValueCallback;
 import com.airbnb.lottie.value.SimpleLottieValueCallback;
@@ -162,6 +163,8 @@ import java.util.Set;
     }
 
     ta.recycle();
+
+    lottieDrawable.setSystemAnimationsAreEnabled(Utils.getAnimationScale(getContext()) != 0f);
 
     enableOrDisableHardwareLayer();
   }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -64,6 +64,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   private LottieComposition composition;
   private final LottieValueAnimator animator = new LottieValueAnimator();
   private float scale = 1f;
+  private boolean systemAnimationsEnabled = true;
 
   private final Set<ColorFilterData> colorFilterData = new HashSet<>();
   private final ArrayList<LazyCompositionTask> lazyCompositionTasks = new ArrayList<>();
@@ -375,7 +376,13 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       });
       return;
     }
-    animator.playAnimation();
+
+    if (systemAnimationsEnabled || getRepeatCount() == 0) {
+      animator.playAnimation();
+    }
+    if (!systemAnimationsEnabled) {
+      setFrame((int) (getSpeed() < 0 ? getMinFrame() : getMaxFrame()));
+    }
   }
 
   @MainThread
@@ -730,6 +737,10 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
 
   public boolean isAnimating() {
     return animator.isRunning();
+  }
+
+  void setSystemAnimationsAreEnabled(Boolean areEnabled) {
+    systemAnimationsEnabled = areEnabled;
   }
 
 // </editor-fold>

--- a/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
@@ -1,5 +1,6 @@
 package com.airbnb.lottie.utils;
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -10,6 +11,8 @@ import android.graphics.Path;
 import android.graphics.PathMeasure;
 import android.graphics.PointF;
 import android.graphics.RectF;
+import android.os.Build;
+import android.provider.Settings;
 
 import androidx.annotation.Nullable;
 
@@ -211,6 +214,17 @@ public final class Utils {
       dpScale = Resources.getSystem().getDisplayMetrics().density;
     }
     return dpScale;
+  }
+
+  public static float getAnimationScale(Context context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      return Settings.Global.getFloat(context.getContentResolver(),
+              Settings.Global.ANIMATOR_DURATION_SCALE, 1.0f);
+    } else {
+      //noinspection deprecation
+      return Settings.System.getFloat(context.getContentResolver(),
+              Settings.System.ANIMATOR_DURATION_SCALE, 1.0f);
+    }
   }
 
   /**


### PR DESCRIPTION
If systemAnimationScale == 0, the lottie animation will play then immediately jump to the last frame, or only jump to the last frame if it is a loop animation. 
This solution handles if the dev move the animation at some percentage, change first or last frame or play the animation in reverse.

Really useful for testing purpose in order to not overload the main thread

Unittest are OK, I couldn't start the uiTest as it require the AWS key.

I couldn't add unittest as it obviously doesn't try to start the animations in it

There is a small Code Review here https://github.com/CmoaToto/lottie-android/pull/1