### PR TITLE
Have software rendering fallback on hardware acceleration

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -34,6 +34,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.airbnb.lottie.RenderMode.HARDWARE;
+import static com.airbnb.lottie.RenderMode.SOFTWARE;
+
 /**
  * This view will load, deserialize, and display an After Effects animation exported with
  * bodymovin (https://github.com/bodymovin/bodymovin).
@@ -804,6 +807,21 @@ import java.util.Set;
   private void clearComposition() {
     composition = null;
     lottieDrawable.clearComposition();
+  }
+
+  /**
+   * If rendering via software, Android will fail to generate a bitmap if the view is too large. Rather than displaying
+   * nothing, fallback on hardware acceleration which may incur a performance hit.
+   *
+   * @see #setRenderMode(RenderMode)
+   * @see com.airbnb.lottie.LottieDrawable#draw(android.graphics.Canvas)
+   */
+  @Override
+  public void buildDrawingCache(boolean autoScale) {
+    super.buildDrawingCache(autoScale);
+    if (getLayerType() == LAYER_TYPE_SOFTWARE && getDrawingCache(autoScale) == null) {
+      setRenderMode(HARDWARE);
+    }
   }
 
   /**


### PR DESCRIPTION
In cases where LottieAnimationView is large and software rendering is used, Android may not be able to generate a bitmap large enough which causes nothing to be shown. Rather than have this happen, fall back on hardware acceleration which is supported > api 11. Potentially taking a perf hit and displaying is better than a blank screen and not displaying at all.

Encountered this where upon rotation on a tablet, the view became big enough that generation of the bitmap failed.