### PR TITLE
Package versions updated

### DIFF
--- a/LottieSample/build.gradle
+++ b/LottieSample/build.gradle
@@ -41,8 +41,8 @@ android {
     baseline file("lint-baseline.xml")
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin'
@@ -75,8 +75,8 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.1'
-  implementation 'com.jakewharton:butterknife:9.0.0-rc1'
-  kapt 'com.jakewharton:butterknife-compiler:9.0.0-rc1'
+  implementation 'com.jakewharton:butterknife:10.1.0'
+  kapt 'com.jakewharton:butterknife-compiler:10.1.0'
   implementation 'com.matthew-tamlin:sliding-intro-screen:3.2.0'
   implementation 'com.dlazaro66.qrcodereaderview:qrcodereaderview:2.0.2'
   implementation 'com.github.PhilJay:MPAndroidChart:v3.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.ajoberstar.grgit.Grgit
 
 buildscript {
-  ext.kotlinVersion = '1.3.0'
+  ext.kotlinVersion = '1.3.31'
   ext.androidXVersion = '1.0.0'
   ext.navVersion = '1.0.0-alpha06'
 
@@ -11,7 +11,7 @@ buildscript {
   }
   dependencies {
     classpath 'org.ajoberstar:grgit:1.9.3'
-    classpath 'com.android.tools.build:gradle:3.2.0'
+    classpath 'com.android.tools.build:gradle:3.4.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
     classpath 'org.ajoberstar:grgit:1.9.3'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 11 23:16:42 PDT 2017
+#Thu May 09 12:19:14 GST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Gradle, Kotlin, Java and Butterknife versions are updated to latest in order to fix the following issue while building lottie-android:

ERROR: The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.10 and higher.
The following dependencies do not satisfy the required version:
root project 'lottie-android' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0