### PR TITLE
Fix old platform behavior which would prevent views from playing on attach

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -259,8 +259,15 @@ import static com.airbnb.lottie.RenderMode.SOFTWARE;
 
   @Override protected void onAttachedToWindow() {
     super.onAttachedToWindow();
-    if (autoPlay && wasAnimatingWhenDetached) {
+    if (autoPlay || wasAnimatingWhenDetached) {
       playAnimation();
+      // Autoplay from xml should only apply once.
+      autoPlay = false;
+    }
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      // This is needed to mimic newer platform behavior.
+      // https://stackoverflow.com/a/53625860/715633
+      onVisibilityChanged(this, getVisibility());
     }
   }
 


### PR DESCRIPTION
The platform check fixes #1243 #1241 
The other logic makes `wasAnimatingWhenDetached` work even if autoPlay is false.

cc @kcoppock