### PR TITLE
Clip masks and mattes to the canvas

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -251,6 +251,10 @@ public abstract class BaseLayer
     matrix.preConcat(transform.getMatrix());
     intersectBoundsWithMask(rect, matrix);
 
+    if (!rect.intersect(0, 0, canvas.getWidth(), canvas.getHeight())) {
+      rect.set(0, 0, 0, 0);
+    }
+
     L.endSection("Layer#computeBounds");
 
     if (!rect.isEmpty()) {


### PR DESCRIPTION
This fixes #1199 _and_ improves performance by never saving a layer outside of the canvas. Thanks to @pmecho for the repro steps!