### PR TITLE
Don't resume animation when system animation is disabled.

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -406,7 +406,9 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       });
       return;
     }
-    animator.resumeAnimation();
+    if (systemAnimationsEnabled) {
+      animator.resumeAnimation();
+    }
   }
 
   /**


### PR DESCRIPTION
While the playAnimation() api call respects systemAnimationsEnabled flag, resumeAnimation() ignores it. Add the condition check to fix the case.