### PR TITLE
Add a fallback resource when compositions fail to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 exposing Lottie's copy of Moshi's json parser.
 * Add the ability to catch all Lottie composition errors with `setFailureListener` and 
 `resetFailureListener` (#1321).
-* Add the ability to set a fallback drawable res when Lottie failes to parse a composition or 
-load it from the internet with `setFallbackResource` and the `setFallbackRes` xml attribute.
+* Add the ability to set a fallback drawable res when Lottie fails to parse a composition or 
+load it from the internet. Use `setFallbackResource` from code or`lottie_fallbackRes` from xml.
 ## Bugs Fixed
 * Prevent masks from either clipping edges or having thin borders pre-Pie.
 * Apply animation scale to dash pattern offsets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 3.1.0
+### Features and Improvements
+* **Breaking Change** Replace JsonReader parsing APIs with InputStream variants to prevent 
+exposing Lottie's copy of Moshi's json parser.
+* Add the ability to catch all Lottie composition errors with `setFailureListener` and 
+`resetFailureListener` (#1321).
+* Add the ability to set a fallback drawable res when Lottie failes to parse a composition or 
+load it from the internet with `setFallbackResource` and the `setFallbackRes` xml attribute.
+## Bugs Fixed
+* Prevent masks from either clipping edges or having thin borders pre-Pie.
+* Apply animation scale to dash pattern offsets.
+* Apply animation scale to gradient strokes.
+* Fuzzy match content types when downloading animations from the internet.
+* Prevent a StackOverflowException on KitKat.
+* Prevent resume from resuming when system animations are disabled.
+
 # 3.0.7
 * Fixed renderMode XML attr being ignored.
 * Allow progress to be set in between frames.

--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/BitmapPool.kt
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/BitmapPool.kt
@@ -7,6 +7,7 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
 import android.util.Log
 import com.airbnb.lottie.L
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
@@ -20,6 +21,7 @@ internal class BitmapPool {
         }
     }
 
+    @ExperimentalCoroutinesApi
     fun acquire(width: Int, height: Int): Bitmap {
         if (width <= 0 || height <= 0) {
             return TRANSPARENT_1X1_BITMAP

--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/LottieTest.kt
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/LottieTest.kt
@@ -62,7 +62,7 @@ class LottieTest {
     private lateinit var snapshotter: HappoSnapshotter
 
     private val bitmapPool by lazy { BitmapPool() }
-    private val dummyBitmap by lazy { BitmapFactory.decodeResource(activity.resources, SampleAppR.drawable.airbnb); }
+    private val dummyBitmap by lazy { BitmapFactory.decodeResource(activity.resources, R.drawable.airbnb); }
 
     private val filmStripViewPool = ObjectPool<FilmStripView> {
         FilmStripView(activity).apply {

--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/LottieTest.kt
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/LottieTest.kt
@@ -62,7 +62,7 @@ class LottieTest {
     private lateinit var snapshotter: HappoSnapshotter
 
     private val bitmapPool by lazy { BitmapPool() }
-    private val dummyBitmap by lazy { BitmapFactory.decodeResource(activity.resources, com.airbnb.lottie.samples.R.drawable.airbnb); }
+    private val dummyBitmap by lazy { BitmapFactory.decodeResource(activity.resources, SampleAppR.drawable.airbnb); }
 
     private val filmStripViewPool = ObjectPool<FilmStripView> {
         FilmStripView(activity).apply {
@@ -99,6 +99,7 @@ class LottieTest {
     @ObsoleteCoroutinesApi
     fun testAll() = runBlocking {
         withTimeout(TimeUnit.MINUTES.toMillis(45)) {
+            snapshotFailure()
             snapshotFrameBoundaries()
             snapshotScaleTypes()
             testDynamicProperties()
@@ -205,6 +206,32 @@ class LottieTest {
                     ?: throw java.lang.IllegalArgumentException("Unable to parse $asset.")
             send(asset to composition)
         }
+    }
+
+    private suspend fun snapshotFailure() {
+        val animationView = animationViewPool.acquire()
+        val semaphore = SuspendingSemaphore(0)
+        animationView.setFailureListener { semaphore.release() }
+        animationView.setFallbackResource(SampleAppR.drawable.ic_close)
+        animationView.setAnimationFromJson("Not Valid Json", null)
+        semaphore.acquire()
+        animationView.layoutParams = FrameLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        animationView.scale = 1f
+        animationView.scaleType = ImageView.ScaleType.FIT_CENTER
+        val widthSpec = View.MeasureSpec.makeMeasureSpec(activity.resources.displayMetrics.widthPixels, View.MeasureSpec.EXACTLY)
+        val heightSpec = View.MeasureSpec.makeMeasureSpec(activity.resources.displayMetrics.heightPixels, View.MeasureSpec.EXACTLY)
+        val animationViewContainer = animationView.parent as ViewGroup
+        animationViewContainer.measure(widthSpec, heightSpec)
+        animationViewContainer.layout(0, 0, animationViewContainer.measuredWidth, animationViewContainer.measuredHeight)
+        val bitmap = bitmapPool.acquire(animationView.width, animationView.height)
+        val canvas = Canvas(bitmap)
+        animationView.draw(canvas)
+        animationViewPool.release(animationView)
+        val snapshotName = "Failure"
+        val snapshotVariant = "Default"
+        snapshotter.record(bitmap, snapshotName, snapshotVariant)
+        activity.recordSnapshot(snapshotName, snapshotVariant)
+        bitmapPool.release(bitmap)
     }
 
     private suspend fun snapshotFrameBoundaries() {

--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/ObjectPool.kt
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/ObjectPool.kt
@@ -2,6 +2,7 @@ package com.airbnb.lottie.samples
 
 import android.util.Log
 import com.airbnb.lottie.L
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import java.util.*
 import kotlin.collections.HashSet
 
@@ -11,6 +12,7 @@ internal class ObjectPool<T>(private val factory: () -> T) {
     private val objects = Collections.synchronizedList(ArrayList<T>())
     private val releasedObjects = HashSet<T>()
 
+    @ExperimentalCoroutinesApi
     fun acquire(): T {
         var blockedStartTime = 0L
         if (semaphore.isFull()) {

--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/SuspendingSemaphore.kt
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/samples/SuspendingSemaphore.kt
@@ -1,5 +1,6 @@
 package com.airbnb.lottie.samples
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 
@@ -29,6 +30,6 @@ class SuspendingSemaphore(limit: Int) {
         }
     }
 
-    @Suppress("EXPERIMENTAL_API_USAGE")
+    @ExperimentalCoroutinesApi
     fun isFull() = bufferedChannel.isFull
 }

--- a/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/DynamicActivity.kt
+++ b/LottieSample/src/main/kotlin/com/airbnb/lottie/samples/DynamicActivity.kt
@@ -49,6 +49,7 @@ class DynamicActivity : AppCompatActivity() {
                 Log.d(TAG, it.keysToString())
             }
         }
+        animationView.setFailureListener { /* do nothing */ }
 
         jumpHeight.postDelayed({ setupValueCallbacks() }, 1000)
         updateButtonText()

--- a/LottieSample/src/main/res/drawable/ic_error.xml
+++ b/LottieSample/src/main/res/drawable/ic_error.xml
@@ -1,0 +1,5 @@
+<vector android:height="48dp" android:tint="#FF0000"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/LottieSample/src/main/res/layout/activity_dynamic.xml
+++ b/LottieSample/src/main/res/layout/activity_dynamic.xml
@@ -10,7 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        airbnb:lottie_fileName="AndroidWave.json"
+        airbnb:lottie_fileName="AndroidWave2.json"
+        airbnb:lottie_fallbackRes="@drawable/ic_error"
         airbnb:lottie_autoPlay="true"
         airbnb:lottie_loop="true"/>
     <Button

--- a/lottie/src/main/res/values/attrs.xml
+++ b/lottie/src/main/res/values/attrs.xml
@@ -4,6 +4,7 @@
         <attr name="lottie_fileName" format="string" />
         <attr name="lottie_rawRes" format="reference" />
         <attr name="lottie_url" format="string" />
+        <attr name="lottie_fallbackRes" format="reference" />
         <attr name="lottie_autoPlay" format="boolean" />
         <attr name="lottie_loop" format="boolean" />
         <attr name="lottie_repeatMode" format="enum">


### PR DESCRIPTION
This may happen either with invalid inputs or when network loading fails.