### PR TITLE
Always use original context (Activity) when obtaining cache key and resource stream to correctly load and handle raw-night resources when the dark mode is on

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -278,7 +278,9 @@ public class LottieCompositionFactory {
       com.airbnb.lottie.parser.moshi.JsonReader reader, @Nullable String cacheKey, boolean close) {
     try {
       LottieComposition composition = LottieCompositionMoshiParser.parse(reader);
-      LottieCompositionCache.getInstance().put(cacheKey, composition);
+      if (cacheKey != null) {
+        LottieCompositionCache.getInstance().put(cacheKey, composition);
+      }
       return new LottieResult<>(composition);
     } catch (Exception e) {
       return new LottieResult<>(e);
@@ -360,7 +362,9 @@ public class LottieCompositionFactory {
       }
     }
 
-    LottieCompositionCache.getInstance().put(cacheKey, composition);
+    if (cacheKey != null) {
+      LottieCompositionCache.getInstance().put(cacheKey, composition);
+    }
     return new LottieResult<>(composition);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -398,9 +398,6 @@ public class LottieCompositionFactory {
     task.addListener(new LottieListener<LottieComposition>() {
       @Override
       public void onResult(LottieComposition result) {
-        if (cacheKey != null) {
-          LottieCompositionCache.getInstance().put(cacheKey, result);
-        }
         taskCache.remove(cacheKey);
       }
     });


### PR DESCRIPTION
Application context isn't reliable source of information about dark mode (uiMode is UI_MODE_NIGHT_NO when the dark mode is on - Activity carries the correct information) and can incorrectly return default resource instead of the -night variant.

Fixes #1305 