### PR TITLE
Fix progress calculation logic with time-remapped layer

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
@@ -117,14 +117,17 @@ public class CompositionLayer extends BaseLayer {
     super.setProgress(progress);
     if (timeRemapping != null) {
       float duration = lottieDrawable.getComposition().getDuration();
-      long remappedTime = (long) (timeRemapping.getValue() * 1000);
+      float compositionDelayTime = layerModel.getComposition().getStartFrame() / layerModel.getComposition().getFrameRate() * 1000;
+      long remappedTime = (long) (timeRemapping.getValue() * 1000 - compositionDelayTime);
       progress = remappedTime / duration;
     }
     if (layerModel.getTimeStretch() != 0) {
       progress /= layerModel.getTimeStretch();
     }
 
-    progress -= layerModel.getStartProgress();
+    if (timeRemapping == null) {
+      progress -= layerModel.getStartProgress();
+    }
     for (int i = layers.size() - 1; i >= 0; i--) {
       layers.get(i).setProgress(progress);
     }


### PR DESCRIPTION
## Objective
There are 2 problem on progress calculating with the layer that is applied time-remapping.

1. If the layer with time-remapping is placed on the way of animation, the progress calculation becomes wrong.
    - The value that is got from `timeRemapping` is already adjusted with `layerModel.getStartProgress()`.
2. If the root layer is started from on the way (`LottieComposition#startFrame` isn't `0`), the child layer with time-remapping is drawn wrongly.
    - The value that is got from `timeRemapping` isn't adjusted with `LottieComposition#startFrame`

## File

[time-remap-test.zip](https://github.com/airbnb/lottie-android/files/3544783/time-remap-test.zip)
