### PR TITLE
Fix rounding-off error on progress calculation with time-remapped layer

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
@@ -116,10 +116,10 @@ public class CompositionLayer extends BaseLayer {
   @Override public void setProgress(@FloatRange(from = 0f, to = 1f) float progress) {
     super.setProgress(progress);
     if (timeRemapping != null) {
-      float duration = lottieDrawable.getComposition().getDuration();
-      float compositionDelayTime = layerModel.getComposition().getStartFrame() / layerModel.getComposition().getFrameRate() * 1000;
-      long remappedTime = (long) (timeRemapping.getValue() * 1000 - compositionDelayTime);
-      progress = remappedTime / duration;
+      float durationInMillis = lottieDrawable.getComposition().getDuration();
+      float compositionDelayTimeInSecond = layerModel.getComposition().getStartFrame() / layerModel.getComposition().getFrameRate();
+      float remappedTimeInMillis = (timeRemapping.getValue() - compositionDelayTimeInSecond) * 1000;
+      progress = remappedTimeInMillis / durationInMillis;
     }
     if (layerModel.getTimeStretch() != 0) {
       progress /= layerModel.getTimeStretch();

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
@@ -116,10 +116,13 @@ public class CompositionLayer extends BaseLayer {
   @Override public void setProgress(@FloatRange(from = 0f, to = 1f) float progress) {
     super.setProgress(progress);
     if (timeRemapping != null) {
-      float durationInMillis = lottieDrawable.getComposition().getDuration();
-      float compositionDelayTimeInSecond = layerModel.getComposition().getStartFrame() / layerModel.getComposition().getFrameRate();
-      float remappedTimeInMillis = (timeRemapping.getValue() - compositionDelayTimeInSecond) * 1000;
-      progress = remappedTimeInMillis / durationInMillis;
+      // The duration has 0.01 frame offset to show end of animation properly.
+      // https://github.com/airbnb/lottie-android/pull/766
+      // Ignore this offset for calculating time-remapping because time-remapping value is based on original duration.
+      float durationFrames = lottieDrawable.getComposition().getDurationFrames() + 0.01f;
+      float compositionDelayFrames = layerModel.getComposition().getStartFrame();
+      float remappedFrames = timeRemapping.getValue() * layerModel.getComposition().getFrameRate() - compositionDelayFrames;
+      progress = remappedFrames / durationFrames;
     }
     if (layerModel.getTimeStretch() != 0) {
       progress /= layerModel.getTimeStretch();


### PR DESCRIPTION
In #1368, progress calculation problem with time-remapping is fixed but it still have a possibility for rounding-off error.
I can't prepare a simple sample for reproduce, but I encount blinking issue with a company internal resource.

