### PR TITLE
Prevent software rendering from getting overwritten

### DIFF
--- a/issue-repro/src/main/res/layout/activity_main.xml
+++ b/issue-repro/src/main/res/layout/activity_main.xml
@@ -4,5 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-
+    <com.airbnb.lottie.LottieAnimationView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        app:lottie_autoPlay="true"
+        app:lottie_loop="true" />
 </FrameLayout>

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -187,7 +187,7 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
       if (renderModeOrdinal >= RenderMode.values().length) {
         renderModeOrdinal = RenderMode.AUTOMATIC.ordinal();
       }
-      renderMode = RenderMode.values()[renderModeOrdinal];
+      setRenderMode(RenderMode.values()[renderModeOrdinal]);
     }
 
     ta.recycle();
@@ -893,12 +893,15 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
    */
   @Override
   public void buildDrawingCache(boolean autoScale) {
+    L.beginSection("buildDrawingCache");
     buildDrawingCacheDepth++;
     super.buildDrawingCache(autoScale);
-    if (buildDrawingCacheDepth == 1 && getLayerType() == LAYER_TYPE_SOFTWARE && getDrawingCache(autoScale) == null) {
+    if (buildDrawingCacheDepth == 1 && getWidth() > 0 && getHeight() > 0 &&
+        getLayerType() == LAYER_TYPE_SOFTWARE && getDrawingCache(autoScale) == null) {
       setRenderMode(HARDWARE);
     }
     buildDrawingCacheDepth--;
+    L.endSection("buildDrawingCache");
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -681,7 +681,9 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       });
       return;
     }
+    L.beginSection("Drawable#setProgress");
     animator.setFrame(MiscUtils.lerp(composition.getStartFrame(), composition.getEndFrame(), progress));
+    L.endSection("Drawable#setProgress");
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/BaseKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/BaseKeyframeAnimation.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.animation.keyframe;
 
 import android.util.Log;
 
+import com.airbnb.lottie.L;
 import com.airbnb.lottie.value.Keyframe;
 import com.airbnb.lottie.value.LottieValueCallback;
 
@@ -82,7 +83,9 @@ public abstract class BaseKeyframeAnimation<K, A> {
   }
 
   protected Keyframe<K> getCurrentKeyframe() {
+    L.beginSection("BaseKeyframeAnimation#getCurrentKeyframe");
     if (cachedKeyframe != null && cachedKeyframe.containsProgress(progress)) {
+      L.endSection("BaseKeyframeAnimation#getCurrentKeyframe");
       return cachedKeyframe;
     }
 
@@ -97,6 +100,7 @@ public abstract class BaseKeyframeAnimation<K, A> {
     }
 
     cachedKeyframe = keyframe;
+    L.endSection("BaseKeyframeAnimation#getCurrentKeyframe");
     return keyframe;
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -168,6 +168,7 @@ public abstract class BaseLayer
 
   @SuppressLint("WrongConstant")
   private void saveLayerCompat(Canvas canvas, RectF rect, Paint paint, boolean all) {
+    L.beginSection("BaseLayer#saveLayer");
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       // This method was deprecated in API level 26 and not recommended since 22, but its
       // 2-parameter replacement is only available starting at API level 21.
@@ -175,6 +176,7 @@ public abstract class BaseLayer
     } else {
       canvas.saveLayer(rect, paint);
     }
+    L.endSection("BaseLayer#saveLayer");
   }
 
   public void addAnimation(@Nullable BaseKeyframeAnimation<?, ?> newAnimation) {

--- a/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/LottieValueAnimator.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import android.view.Choreographer;
 
+import com.airbnb.lottie.L;
 import com.airbnb.lottie.LottieComposition;
 
 /**
@@ -82,6 +83,7 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
       return;
     }
 
+    L.beginSection("LottieValueAnimator#doFrame");
     long now = frameTimeNanos;
     long timeSinceFrame = lastFrameTimeNs == 0 ? 0 : now - lastFrameTimeNs;
     float frameDuration = getFrameDurationNs();
@@ -113,6 +115,7 @@ public class LottieValueAnimator extends BaseLottieAnimator implements Choreogra
     }
 
     verifyFrame();
+    L.endSection("LottieValueAnimator#doFrame");
   }
 
   private float getFrameDurationNs() {


### PR DESCRIPTION
[This](https://github.com/airbnb/lottie-android/pull/1190) change was supposed to revert to software rendering when the device can't allocate a hardware buffer large enough for the animation. However, this would also trigger before a composition loads and the view was set to wrap_content. The width and heigh would be 0 which would cause Android to noop the drawing cache. However, the previous logic here would think that the drawing cache failed to allocate because it was too large.

I also added some systrace markers and added a default animation view to the issue repro module.

Fixes #1374 