### PR TITLE
Early return for GammaEvaluator.evaluate()

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/utils/GammaEvaluator.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/GammaEvaluator.java
@@ -4,7 +4,7 @@ package com.airbnb.lottie.utils;
  * Use this instead of {@link android.animation.ArgbEvaluator} because it interpolates through the gamma color
  * space which looks better to us humans.
  * <p>
- * Writted by Romain Guy and Francois Blavoet.
+ * Written by Romain Guy and Francois Blavoet.
  * https://androidstudygroup.slack.com/archives/animation/p1476461064000335
  */
 public class GammaEvaluator {
@@ -25,6 +25,9 @@ public class GammaEvaluator {
   }
 
   public static int evaluate(float fraction, int startInt, int endInt) {
+    if (startInt == endInt) {
+      return startInt;
+    }
     float startA = ((startInt >> 24) & 0xff) / 255.0f;
     float startR = ((startInt >> 16) & 0xff) / 255.0f;
     float startG = ((startInt >> 8) & 0xff) / 255.0f;

--- a/lottie/src/test/java/com/airbnb/lottie/utils/GammaEvaluatorTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/utils/GammaEvaluatorTest.java
@@ -1,0 +1,19 @@
+package com.airbnb.lottie.utils;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class GammaEvaluatorTest {
+  @Test
+  public void testEvaluateForSameColorValues() {
+    int count = 0;
+    for (int color = 0x000000; color <= 0xffffff; color++) {
+      int actual = GammaEvaluator.evaluate(0.3f, color, color);
+      assertThat(actual, is(color));
+      count++;
+    }
+    assertThat(count, is(0x1000000));
+  }
+}

--- a/lottie/src/test/java/com/airbnb/lottie/utils/GammaEvaluatorTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/utils/GammaEvaluatorTest.java
@@ -8,12 +8,9 @@ import static org.junit.Assert.*;
 public class GammaEvaluatorTest {
   @Test
   public void testEvaluateForSameColorValues() {
-    int count = 0;
     for (int color = 0x000000; color <= 0xffffff; color++) {
       int actual = GammaEvaluator.evaluate(0.3f, color, color);
       assertThat(actual, is(color));
-      count++;
     }
-    assertThat(count, is(0x1000000));
   }
 }


### PR DESCRIPTION
if `startInt` and `endInt` are same valule, the method always returns `startInt` (or `endInt`) value. 