### PR TITLE
Fix opacity used in save layer

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -247,7 +247,7 @@ public abstract class BaseLayer
 
     if (!rect.isEmpty()) {
       L.beginSection("Layer#saveLayer");
-      contentPaint.setAlpha(alpha);
+      contentPaint.setAlpha(255);
       Utils.saveLayerCompat(canvas, rect, contentPaint);
       L.endSection("Layer#saveLayer");
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -247,6 +247,7 @@ public abstract class BaseLayer
 
     if (!rect.isEmpty()) {
       L.beginSection("Layer#saveLayer");
+      contentPaint.setAlpha(alpha);
       Utils.saveLayerCompat(canvas, rect, contentPaint);
       L.endSection("Layer#saveLayer");
 


### PR DESCRIPTION
`contentPaint.alpha` is changed multiple times without reset it back. This will lead to `Utils.saveLayerCompat` call with incorrect alpha. 
In our case it should be 255, but if last mask was applied with 0 alpha (e.g. in `applyAddMask`), next draw will be transparent, because layer will be saved with 0 alpha.

Fix is to set proper alpha before saving layer. 