### PR TITLE
Improve primitive BaseKeyframeAnimation.getValue() performance

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/BaseStrokeContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/BaseStrokeContent.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.airbnb.lottie.utils.MiscUtils.clamp;
+import static com.airbnb.lottie.utils.Utils.getFloatValue;
 
 public abstract class BaseStrokeContent
     implements BaseKeyframeAnimation.AnimationListener, KeyPathElementContent, DrawingContent {
@@ -193,11 +194,11 @@ public abstract class BaseStrokeContent
     while (pm.nextContour()) {
       totalLength += pm.getLength();
     }
-    float offsetLength = totalLength * pathGroup.trimPath.getOffset().getValue() / 360f;
+    float offsetLength = totalLength * getFloatValue(pathGroup.trimPath.getOffset()) / 360f;
     float startLength =
-        totalLength * pathGroup.trimPath.getStart().getValue() / 100f + offsetLength;
+        totalLength * getFloatValue(pathGroup.trimPath.getStart()) / 100f + offsetLength;
     float endLength =
-        totalLength * pathGroup.trimPath.getEnd().getValue() / 100f + offsetLength;
+        totalLength * getFloatValue(pathGroup.trimPath.getEnd()) / 100f + offsetLength;
 
     float currentLength = 0;
     for (int j = pathGroup.paths.size() - 1; j >= 0; j--) {
@@ -279,7 +280,7 @@ public abstract class BaseStrokeContent
 
     float scale = Utils.getScale(parentMatrix);
     for (int i = 0; i < dashPatternAnimations.size(); i++) {
-      dashPatternValues[i] = dashPatternAnimations.get(i).getValue();
+      dashPatternValues[i] = getFloatValue(dashPatternAnimations.get(i));
       // If the value of the dash pattern or gap is too small, the number of individual sections
       // approaches infinity as the value approaches 0.
       // To mitigate this, we essentially put a minimum value on the dash pattern size of 1px
@@ -295,7 +296,7 @@ public abstract class BaseStrokeContent
       }
       dashPatternValues[i] *= scale;
     }
-    float offset = dashPatternOffsetAnimation == null ? 0f : dashPatternOffsetAnimation.getValue() * scale;
+    float offset = getFloatValue(dashPatternOffsetAnimation, 0f) * scale;
     paint.setPathEffect(new DashPathEffect(dashPatternValues, offset));
     L.endSection("StrokeContent#applyDashPattern");
   }

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/ContentGroup.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/ContentGroup.java
@@ -6,6 +6,8 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
 
+import androidx.annotation.Nullable;
+
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.LPaint;
 import com.airbnb.lottie.animation.keyframe.BaseKeyframeAnimation;
@@ -22,7 +24,7 @@ import com.airbnb.lottie.value.LottieValueCallback;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.Nullable;
+import static com.airbnb.lottie.utils.Utils.getIntValue;
 
 public class ContentGroup implements DrawingContent, PathContent,
     BaseKeyframeAnimation.AnimationListener, KeyPathElement {
@@ -163,7 +165,7 @@ public class ContentGroup implements DrawingContent, PathContent,
     int layerAlpha;
     if (transformAnimation != null) {
       matrix.preConcat(transformAnimation.getMatrix());
-      int opacity = transformAnimation.getOpacity() == null ? 100 : transformAnimation.getOpacity().getValue();
+      int opacity = getIntValue(transformAnimation.getOpacity(), 100);
       layerAlpha = (int) ((opacity / 100f * parentAlpha / 255f) * 255);
     } else {
       layerAlpha = parentAlpha;

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/FillContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/FillContent.java
@@ -6,6 +6,7 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
+
 import androidx.annotation.Nullable;
 
 import com.airbnb.lottie.L;
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.airbnb.lottie.utils.MiscUtils.clamp;
+import static com.airbnb.lottie.utils.Utils.getIntValue;
 
 public class FillContent
     implements DrawingContent, BaseKeyframeAnimation.AnimationListener, KeyPathElementContent {
@@ -83,7 +85,7 @@ public class FillContent
     }
     L.beginSection("FillContent#draw");
     paint.setColor(((ColorKeyframeAnimation) colorAnimation).getIntValue());
-    int alpha = (int) ((parentAlpha / 255f * opacityAnimation.getValue() / 100f) * 255);
+    int alpha = (int) ((parentAlpha / 255f * getIntValue(opacityAnimation) / 100f) * 255);
     paint.setAlpha(clamp(alpha, 0, 255));
 
     if (colorFilterAnimation != null) {

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/GradientFillContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/GradientFillContent.java
@@ -10,6 +10,7 @@ import android.graphics.PointF;
 import android.graphics.RadialGradient;
 import android.graphics.RectF;
 import android.graphics.Shader;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.collection.LongSparseArray;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.airbnb.lottie.utils.MiscUtils.clamp;
+import static com.airbnb.lottie.utils.Utils.getIntValue;
 
 public class GradientFillContent
     implements DrawingContent, BaseKeyframeAnimation.AnimationListener, KeyPathElementContent {
@@ -122,7 +124,7 @@ public class GradientFillContent
       paint.setColorFilter(colorFilterAnimation.getValue());
     }
 
-    int alpha = (int) ((parentAlpha / 255f * opacityAnimation.getValue() / 100f) * 255);
+    int alpha = (int) ((parentAlpha / 255f * getIntValue(opacityAnimation) / 100f) * 255);
     paint.setAlpha(clamp(alpha, 0, 255));
 
     canvas.drawPath(path, paint);

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/PolystarContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/PolystarContent.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.animation.content;
 
 import android.graphics.Path;
 import android.graphics.PointF;
+
 import androidx.annotation.Nullable;
 
 import com.airbnb.lottie.LottieDrawable;
@@ -15,6 +16,8 @@ import com.airbnb.lottie.utils.MiscUtils;
 import com.airbnb.lottie.value.LottieValueCallback;
 
 import java.util.List;
+
+import static com.airbnb.lottie.utils.Utils.getFloatValue;
 
 public class PolystarContent
     implements PathContent, BaseKeyframeAnimation.AnimationListener, KeyPathElementContent {
@@ -139,8 +142,8 @@ public class PolystarContent
   }
 
   private void createStarPath() {
-    float points = pointsAnimation.getValue();
-    double currentAngle = rotationAnimation == null ? 0f : rotationAnimation.getValue();
+    float points = getFloatValue(pointsAnimation);
+    double currentAngle = getFloatValue(rotationAnimation, 0f);
     // Start at +y instead of +x
     currentAngle -= 90;
     // convert to radians
@@ -153,18 +156,12 @@ public class PolystarContent
       currentAngle += halfAnglePerPoint * (1f - partialPointAmount);
     }
 
-    float outerRadius = outerRadiusAnimation.getValue();
+    float outerRadius = getFloatValue(outerRadiusAnimation);
     //noinspection ConstantConditions
-    float innerRadius = innerRadiusAnimation.getValue();
+    float innerRadius = getFloatValue(innerRadiusAnimation);
 
-    float innerRoundedness = 0f;
-    if (innerRoundednessAnimation != null) {
-      innerRoundedness = innerRoundednessAnimation.getValue() / 100f;
-    }
-    float outerRoundedness = 0f;
-    if (outerRoundednessAnimation != null) {
-      outerRoundedness = outerRoundednessAnimation.getValue() / 100f;
-    }
+    final float innerRoundedness = getFloatValue(innerRoundednessAnimation, 0f) / 100f;
+    final float outerRoundedness = getFloatValue(outerRoundednessAnimation, 0f) / 100f;
 
     float x;
     float y;
@@ -245,8 +242,8 @@ public class PolystarContent
   }
 
   private void createPolygonPath() {
-    int points = (int) Math.floor(pointsAnimation.getValue());
-    double currentAngle = rotationAnimation == null ? 0f : rotationAnimation.getValue();
+    int points = (int) Math.floor(getFloatValue(pointsAnimation));
+    double currentAngle = getFloatValue(rotationAnimation, 0f);
     // Start at +y instead of +x
     currentAngle -= 90;
     // convert to radians
@@ -254,8 +251,8 @@ public class PolystarContent
     // adjust current angle for partial points
     float anglePerPoint = (float) (2 * Math.PI / points);
 
-    float roundedness = outerRoundednessAnimation.getValue() / 100f;
-    float radius = outerRadiusAnimation.getValue();
+    float roundedness = getFloatValue(outerRoundednessAnimation) / 100f;
+    float radius = getFloatValue(outerRadiusAnimation);
     float x;
     float y;
     float previousX;

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/RectangleContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/RectangleContent.java
@@ -4,10 +4,11 @@ import android.graphics.Path;
 import android.graphics.PointF;
 import android.graphics.RectF;
 
+import androidx.annotation.Nullable;
+
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.LottieProperty;
 import com.airbnb.lottie.animation.keyframe.BaseKeyframeAnimation;
-import com.airbnb.lottie.animation.keyframe.FloatKeyframeAnimation;
 import com.airbnb.lottie.model.KeyPath;
 import com.airbnb.lottie.model.content.RectangleShape;
 import com.airbnb.lottie.model.content.ShapeTrimPath;
@@ -17,7 +18,7 @@ import com.airbnb.lottie.value.LottieValueCallback;
 
 import java.util.List;
 
-import androidx.annotation.Nullable;
+import static com.airbnb.lottie.utils.Utils.getFloatValue;
 
 public class RectangleContent
     implements BaseKeyframeAnimation.AnimationListener, KeyPathElementContent, PathContent {
@@ -95,8 +96,7 @@ public class RectangleContent
     PointF size = sizeAnimation.getValue();
     float halfWidth = size.x / 2f;
     float halfHeight = size.y / 2f;
-    float radius = cornerRadiusAnimation == null ?
-        0f : ((FloatKeyframeAnimation) cornerRadiusAnimation).getFloatValue();
+    float radius = getFloatValue(cornerRadiusAnimation, 0f);
     float maxRadius = Math.min(halfWidth, halfHeight);
     if (radius > maxRadius) {
       radius = maxRadius;

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/RepeaterContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/RepeaterContent.java
@@ -4,6 +4,7 @@ import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Path;
 import android.graphics.RectF;
+
 import androidx.annotation.Nullable;
 
 import com.airbnb.lottie.LottieDrawable;
@@ -20,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
+
+import static com.airbnb.lottie.utils.Utils.getFloatValue;
 
 public class RepeaterContent implements DrawingContent, PathContent, GreedyContent,
     BaseKeyframeAnimation.AnimationListener, KeyPathElementContent {
@@ -94,8 +97,8 @@ public class RepeaterContent implements DrawingContent, PathContent, GreedyConte
   @Override public Path getPath() {
     Path contentPath = contentGroup.getPath();
     path.reset();
-    float copies = this.copies.getValue();
-    float offset = this.offset.getValue();
+    float copies = getFloatValue(this.copies);
+    float offset = getFloatValue(this.offset);
     for (int i = (int) copies - 1; i >= 0; i--) {
       matrix.set(transform.getMatrixForRepeater(i + offset));
       path.addPath(contentPath, matrix);
@@ -104,12 +107,12 @@ public class RepeaterContent implements DrawingContent, PathContent, GreedyConte
   }
 
   @Override public void draw(Canvas canvas, Matrix parentMatrix, int alpha) {
-    float copies = this.copies.getValue();
-    float offset = this.offset.getValue();
+    float copies = getFloatValue(this.copies);
+    float offset = getFloatValue(this.offset);
     //noinspection ConstantConditions
-    float startOpacity = this.transform.getStartOpacity().getValue() / 100f;
+    float startOpacity = getFloatValue(this.transform.getStartOpacity()) / 100f;
     //noinspection ConstantConditions
-    float endOpacity = this.transform.getEndOpacity().getValue() / 100f;
+    float endOpacity = getFloatValue(this.transform.getEndOpacity()) / 100f;
     for (int i = (int) copies - 1; i >= 0; i--) {
       matrix.set(parentMatrix);
       matrix.preConcat(transform.getMatrixForRepeater(i + offset));

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/BaseKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/BaseKeyframeAnimation.java
@@ -24,7 +24,7 @@ public abstract class BaseKeyframeAnimation<K, A> {
   final List<AnimationListener> listeners = new ArrayList<>(1);
   private boolean isDiscrete = false;
 
-  private final KeyframesWrapper<K> keyframesWrapper;
+  final KeyframesWrapper<K> keyframesWrapper;
   private float progress = 0f;
   @Nullable protected LottieValueCallback<A> valueCallback;
 
@@ -167,7 +167,7 @@ public abstract class BaseKeyframeAnimation<K, A> {
     return new KeyframesWrapperImpl<>(keyframes);
   }
 
-  private interface KeyframesWrapper<T> {
+  interface KeyframesWrapper<T> {
     boolean isEmpty();
 
     boolean isValueChanged(float progress);

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/ColorKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/ColorKeyframeAnimation.java
@@ -36,13 +36,20 @@ public class ColorKeyframeAnimation extends KeyframeAnimation<Integer> {
       }
     }
 
-    return GammaEvaluator.evaluate(MiscUtils.clamp(keyframeProgress, 0f, 1f), startColor, endColor);
+    int value = GammaEvaluator.evaluate(MiscUtils.clamp(keyframeProgress, 0f, 1f), startColor, endColor);
+    cachedValue = value;
+    return value;
   }
 
   /**
    * Optimization to avoid autoboxing.
    */
+  private int cachedValue = 0;
   public int getIntValue() {
-    return getIntValue(getCurrentKeyframe(), getInterpolatedCurrentKeyframeProgress());
+    float interpolatedProgress = getInterpolatedCurrentKeyframeProgress();
+    if (valueCallback == null && keyframesWrapper.isCachedValueEnabled(interpolatedProgress)) {
+      return cachedValue;
+    }
+    return getIntValue(getCurrentKeyframe(), interpolatedProgress);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/FloatKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/FloatKeyframeAnimation.java
@@ -33,13 +33,20 @@ public class FloatKeyframeAnimation extends KeyframeAnimation<Float> {
       }
     }
 
-    return MiscUtils.lerp(keyframe.getStartValueFloat(), keyframe.getEndValueFloat(), keyframeProgress);
+    float value = MiscUtils.lerp(keyframe.getStartValueFloat(), keyframe.getEndValueFloat(), keyframeProgress);
+    cachedValue = value;
+    return value;
   }
 
   /**
    * Optimization to avoid autoboxing.
    */
+  private float cachedValue = 0f;
   public float getFloatValue() {
-    return getFloatValue(getCurrentKeyframe(), getInterpolatedCurrentKeyframeProgress());
+    float interpolatedProgress = getInterpolatedCurrentKeyframeProgress();
+    if (valueCallback == null && keyframesWrapper.isCachedValueEnabled(interpolatedProgress)) {
+      return cachedValue;
+    }
+    return getFloatValue(getCurrentKeyframe(), interpolatedProgress);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/IntegerKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/IntegerKeyframeAnimation.java
@@ -34,13 +34,20 @@ public class IntegerKeyframeAnimation extends KeyframeAnimation<Integer> {
       }
     }
 
-    return MiscUtils.lerp(keyframe.getStartValueInt(), keyframe.getEndValueInt(), keyframeProgress);
+    int value = MiscUtils.lerp(keyframe.getStartValueInt(), keyframe.getEndValueInt(), keyframeProgress);
+    cachedValue = value;
+    return value;
   }
 
   /**
    * Optimization to avoid autoboxing.
    */
+  private int cachedValue = 0;
   public int getIntValue() {
-    return getIntValue(getCurrentKeyframe(), getInterpolatedCurrentKeyframeProgress());
+    float interpolatedProgress = getInterpolatedCurrentKeyframeProgress();
+    if (valueCallback == null && keyframesWrapper.isCachedValueEnabled(interpolatedProgress)) {
+      return cachedValue;
+    }
+    return getIntValue(getCurrentKeyframe(), interpolatedProgress);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/SplitDimensionPathKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/SplitDimensionPathKeyframeAnimation.java
@@ -6,6 +6,8 @@ import com.airbnb.lottie.value.Keyframe;
 
 import java.util.Collections;
 
+import static com.airbnb.lottie.utils.Utils.getFloatValue;
+
 public class SplitDimensionPathKeyframeAnimation extends BaseKeyframeAnimation<PointF, PointF> {
   private final PointF point = new PointF();
   private final BaseKeyframeAnimation<Float, Float> xAnimation;
@@ -25,7 +27,7 @@ public class SplitDimensionPathKeyframeAnimation extends BaseKeyframeAnimation<P
   @Override public void setProgress(float progress) {
     xAnimation.setProgress(progress);
     yAnimation.setProgress(progress);
-    point.set(xAnimation.getValue(), yAnimation.getValue());
+    point.set(getFloatValue(xAnimation), getFloatValue(yAnimation));
     for (int i = 0; i < listeners.size(); i++) {
       listeners.get(i).onValueChanged();
     }

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/TransformKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/TransformKeyframeAnimation.java
@@ -2,14 +2,15 @@ package com.airbnb.lottie.animation.keyframe;
 
 import android.graphics.Matrix;
 import android.graphics.PointF;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.model.animatable.AnimatableTransform;
+import com.airbnb.lottie.model.layer.BaseLayer;
 import com.airbnb.lottie.value.Keyframe;
 import com.airbnb.lottie.value.LottieValueCallback;
 import com.airbnb.lottie.value.ScaleXY;
-import com.airbnb.lottie.model.animatable.AnimatableTransform;
-import com.airbnb.lottie.model.layer.BaseLayer;
 
 import java.util.Collections;
 
@@ -22,6 +23,7 @@ import static com.airbnb.lottie.LottieProperty.TRANSFORM_SCALE;
 import static com.airbnb.lottie.LottieProperty.TRANSFORM_SKEW;
 import static com.airbnb.lottie.LottieProperty.TRANSFORM_SKEW_ANGLE;
 import static com.airbnb.lottie.LottieProperty.TRANSFORM_START_OPACITY;
+import static com.airbnb.lottie.utils.Utils.getFloatValue;
 
 public class TransformKeyframeAnimation {
   private final Matrix matrix = new Matrix();
@@ -172,12 +174,7 @@ public class TransformKeyframeAnimation {
     }
 
     if (rotation != null) {
-      float rotation;
-      if (this.rotation instanceof ValueCallbackKeyframeAnimation) {
-          rotation = this.rotation.getValue();
-      } else {
-        rotation = ((FloatKeyframeAnimation) this.rotation).getFloatValue();
-      }
+      float rotation = getFloatValue(this.rotation);
       if (rotation != 0f) {
         matrix.preRotate(rotation);
       }
@@ -253,7 +250,7 @@ public class TransformKeyframeAnimation {
           (float) Math.pow(scale.getScaleY(), amount));
     }
     if (this.rotation != null) {
-      float rotation = this.rotation.getValue();
+      float rotation = getFloatValue(this.rotation);
       PointF anchorPoint = this.anchorPoint == null ? null : this.anchorPoint.getValue();
       matrix.preRotate(rotation * amount, anchorPoint == null ? 0f : anchorPoint.x, anchorPoint == null ? 0f : anchorPoint.y);
     }

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.airbnb.lottie.utils.Utils.getIntValue;
+
 public abstract class BaseLayer
     implements DrawingContent, BaseKeyframeAnimation.AnimationListener, KeyPathElement {
   /**
@@ -212,7 +214,7 @@ public abstract class BaseLayer
       matrix.preConcat(parentLayers.get(i).transform.getMatrix());
     }
     L.endSection("Layer#parentMatrix");
-    int opacity = transform.getOpacity() == null ? 100 : transform.getOpacity().getValue();
+    int opacity = getIntValue(transform.getOpacity(), 100);
     int alpha = (int)
         ((parentAlpha / 255f * (float) opacity / 100f) * 255);
     if (!hasMatteOnThisLayer() && !hasMasksOnThisLayer()) {
@@ -443,7 +445,7 @@ public abstract class BaseLayer
     Path maskPath = maskAnimation.getValue();
     path.set(maskPath);
     path.transform(matrix);
-    contentPaint.setAlpha((int) (opacityAnimation.getValue() * 2.55f));
+    contentPaint.setAlpha((int) (getIntValue(opacityAnimation) * 2.55f));
     canvas.drawPath(path, contentPaint);
   }
 
@@ -454,7 +456,7 @@ public abstract class BaseLayer
     Path maskPath = maskAnimation.getValue();
     path.set(maskPath);
     path.transform(matrix);
-    contentPaint.setAlpha((int) (opacityAnimation.getValue() * 2.55f));
+    contentPaint.setAlpha((int) (getIntValue(opacityAnimation) * 2.55f));
     canvas.drawPath(path, dstOutPaint);
     canvas.restore();
   }
@@ -471,7 +473,7 @@ public abstract class BaseLayer
       BaseKeyframeAnimation<ShapeData, Path> maskAnimation, BaseKeyframeAnimation<Integer, Integer> opacityAnimation) {
     Utils.saveLayerCompat(canvas, rect, dstOutPaint);
     canvas.drawRect(rect, contentPaint);
-    dstOutPaint.setAlpha((int) (opacityAnimation.getValue() * 2.55f));
+    dstOutPaint.setAlpha((int) (getIntValue(opacityAnimation) * 2.55f));
     Path maskPath = maskAnimation.getValue();
     path.set(maskPath);
     path.transform(matrix);
@@ -485,7 +487,7 @@ public abstract class BaseLayer
     Path maskPath = maskAnimation.getValue();
     path.set(maskPath);
     path.transform(matrix);
-    contentPaint.setAlpha((int) (opacityAnimation.getValue() * 2.55f));
+    contentPaint.setAlpha((int) (getIntValue(opacityAnimation) * 2.55f));
     canvas.drawPath(path, contentPaint);
     canvas.restore();
   }
@@ -494,7 +496,7 @@ public abstract class BaseLayer
       BaseKeyframeAnimation<ShapeData, Path> maskAnimation, BaseKeyframeAnimation<Integer, Integer> opacityAnimation) {
     Utils.saveLayerCompat(canvas, rect, dstInPaint);
     canvas.drawRect(rect, contentPaint);
-    dstOutPaint.setAlpha((int) (opacityAnimation.getValue() * 2.55f));
+    dstOutPaint.setAlpha((int) (getIntValue(opacityAnimation) * 2.55f));
     Path maskPath = maskAnimation.getValue();
     path.set(maskPath);
     path.transform(matrix);

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -154,7 +154,7 @@ public abstract class BaseLayer
           setVisible(inOutAnimation.getFloatValue() == 1f);
         }
       });
-      setVisible(inOutAnimation.getValue() == 1f);
+      setVisible(inOutAnimation.getFloatValue() == 1f);
       addAnimation(inOutAnimation);
     } else {
       setVisible(true);

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/CompositionLayer.java
@@ -5,6 +5,10 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.RectF;
 
+import androidx.annotation.FloatRange;
+import androidx.annotation.Nullable;
+import androidx.collection.LongSparseArray;
+
 import com.airbnb.lottie.L;
 import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
@@ -19,9 +23,7 @@ import com.airbnb.lottie.value.LottieValueCallback;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.FloatRange;
-import androidx.annotation.Nullable;
-import androidx.collection.LongSparseArray;
+import static com.airbnb.lottie.utils.Utils.getFloatValue;
 
 public class CompositionLayer extends BaseLayer {
   @Nullable private BaseKeyframeAnimation<Float, Float> timeRemapping;
@@ -134,7 +136,7 @@ public class CompositionLayer extends BaseLayer {
       // Ignore this offset for calculating time-remapping because time-remapping value is based on original duration.
       float durationFrames = lottieDrawable.getComposition().getDurationFrames() + 0.01f;
       float compositionDelayFrames = layerModel.getComposition().getStartFrame();
-      float remappedFrames = timeRemapping.getValue() * layerModel.getComposition().getFrameRate() - compositionDelayFrames;
+      float remappedFrames = getFloatValue(timeRemapping) * layerModel.getComposition().getFrameRate() - compositionDelayFrames;
       progress = remappedFrames / durationFrames;
     }
     if (layerModel.getTimeStretch() != 0) {

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/SolidLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/SolidLayer.java
@@ -7,6 +7,7 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
+
 import androidx.annotation.Nullable;
 
 import com.airbnb.lottie.LottieDrawable;
@@ -15,6 +16,8 @@ import com.airbnb.lottie.animation.LPaint;
 import com.airbnb.lottie.animation.keyframe.BaseKeyframeAnimation;
 import com.airbnb.lottie.animation.keyframe.ValueCallbackKeyframeAnimation;
 import com.airbnb.lottie.value.LottieValueCallback;
+
+import static com.airbnb.lottie.utils.Utils.getIntValue;
 
 public class SolidLayer extends BaseLayer {
   private final RectF rect = new RectF();
@@ -39,7 +42,7 @@ public class SolidLayer extends BaseLayer {
       return;
     }
 
-    int opacity = transform.getOpacity() == null ? 100 : transform.getOpacity().getValue();
+    int opacity = getIntValue(transform.getOpacity(), 100);
     int alpha = (int) (parentAlpha / 255f * (backgroundAlpha / 255f * opacity / 100f) * 255);
     paint.setAlpha(alpha);
     if (colorFilterAnimation != null) {

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
@@ -32,6 +32,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.airbnb.lottie.utils.Utils.getFloatValue;
+import static com.airbnb.lottie.utils.Utils.getIntValue;
+
 public class TextLayer extends BaseLayer {
   // Capacity is 2 because emojis are 2 characters. Some are longer in which case, the capacity will
   // be expanded but that should be pretty rare.
@@ -116,24 +119,16 @@ public class TextLayer extends BaseLayer {
       return;
     }
 
-    if (colorAnimation != null) {
-      fillPaint.setColor(colorAnimation.getValue());
-    } else {
-      fillPaint.setColor(documentData.color);
-    }
+    fillPaint.setColor(getIntValue(colorAnimation, documentData.color));
+    strokePaint.setColor(getIntValue(strokeColorAnimation, documentData.strokeColor));
 
-    if (strokeColorAnimation != null) {
-      strokePaint.setColor(strokeColorAnimation.getValue());
-    } else {
-      strokePaint.setColor(documentData.strokeColor);
-    }
-    int opacity = transform.getOpacity() == null ? 100 : transform.getOpacity().getValue();
+    int opacity = getIntValue(transform.getOpacity(), 100);
     int alpha = opacity * 255 / 100;
     fillPaint.setAlpha(alpha);
     strokePaint.setAlpha(alpha);
 
     if (strokeWidthAnimation != null) {
-      strokePaint.setStrokeWidth(strokeWidthAnimation.getValue());
+      strokePaint.setStrokeWidth(getFloatValue(strokeWidthAnimation));
     } else {
       float parentScale = Utils.getScale(parentMatrix);
       strokePaint.setStrokeWidth(documentData.strokeWidth * Utils.dpScale() * parentScale);
@@ -150,7 +145,7 @@ public class TextLayer extends BaseLayer {
 
   private void drawTextGlyphs(
       DocumentData documentData, Matrix parentMatrix, Font font, Canvas canvas) {
-    float textSize = textSizeAnimation == null ? documentData.size : textSizeAnimation.getValue();
+    float textSize = getFloatValue(textSizeAnimation, documentData.size);
     float fontScale = textSize / 100f;
     float parentScale = Utils.getScale(parentMatrix);
 
@@ -200,7 +195,7 @@ public class TextLayer extends BaseLayer {
       // Add tracking
       float tracking = documentData.tracking / 10f;
       if (trackingAnimation != null) {
-        tracking += trackingAnimation.getValue();
+        tracking += getFloatValue(trackingAnimation);
       }
       tx += tracking * parentScale;
       canvas.translate(tx, 0);
@@ -220,7 +215,7 @@ public class TextLayer extends BaseLayer {
       text = textDelegate.getTextInternal(text);
     }
     fillPaint.setTypeface(typeface);
-    float textSize = textSizeAnimation == null ? documentData.size : textSizeAnimation.getValue();
+    float textSize = getFloatValue(textSizeAnimation, documentData.size);
     fillPaint.setTextSize(textSize * Utils.dpScale());
     strokePaint.setTypeface(fillPaint.getTypeface());
     strokePaint.setTextSize(fillPaint.getTextSize());
@@ -269,7 +264,7 @@ public class TextLayer extends BaseLayer {
       // Add tracking
       float tracking = documentData.tracking / 10f;
       if (trackingAnimation != null) {
-        tracking += trackingAnimation.getValue();
+        tracking += getFloatValue(trackingAnimation);
       }
       float tx = charWidth + tracking * parentScale;
       canvas.translate(tx, 0);

--- a/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
@@ -14,12 +14,16 @@ import android.graphics.RectF;
 import android.os.Build;
 import android.provider.Settings;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.airbnb.lottie.L;
 import com.airbnb.lottie.animation.LPaint;
 import com.airbnb.lottie.animation.content.TrimPathContent;
+import com.airbnb.lottie.animation.keyframe.BaseKeyframeAnimation;
+import com.airbnb.lottie.animation.keyframe.ColorKeyframeAnimation;
 import com.airbnb.lottie.animation.keyframe.FloatKeyframeAnimation;
+import com.airbnb.lottie.animation.keyframe.IntegerKeyframeAnimation;
 
 import java.io.Closeable;
 import java.io.InterruptedIOException;
@@ -271,6 +275,31 @@ public final class Utils {
       canvas.saveLayer(rect, paint);
     }
     L.endSection("Utils#saveLayer");
+  }
+
+  public static float getFloatValue(@Nullable BaseKeyframeAnimation<?, Float> keyframeAnimation, float defValue) {
+    return keyframeAnimation == null ? defValue : getFloatValue(keyframeAnimation);
+  }
+
+  public static float getFloatValue(@NonNull BaseKeyframeAnimation<?, Float> keyframeAnimation) {
+    if (keyframeAnimation instanceof FloatKeyframeAnimation) {
+      return ((FloatKeyframeAnimation) keyframeAnimation).getFloatValue();
+    }
+    return keyframeAnimation.getValue();
+  }
+
+  public static int getIntValue(@Nullable BaseKeyframeAnimation<?, Integer> keyframeAnimation, int defValue) {
+    return keyframeAnimation == null ? defValue : getIntValue(keyframeAnimation);
+  }
+
+  public static int getIntValue(@NonNull BaseKeyframeAnimation<?, Integer> keyframeAnimation) {
+    if (keyframeAnimation instanceof IntegerKeyframeAnimation) {
+      return ((IntegerKeyframeAnimation) keyframeAnimation).getIntValue();
+    }
+    if (keyframeAnimation instanceof ColorKeyframeAnimation) {
+      return ((ColorKeyframeAnimation) keyframeAnimation).getIntValue();
+    }
+    return keyframeAnimation.getValue();
   }
 
   /**


### PR DESCRIPTION
- introduced `cacheValue` for Int/Color/FloatKeyframeAnimation
- for process that calling directly `getIntValue()`/`getFloatValue()`, can be simply improved processing speed
- for process that calling `BaseKeyframeAnimation.getValue()`, to replace with `Utils.getIntValue()`/`getFloatValue()` makes  autoboxing/unboxing reduced