### PR TITLE
add: support android drawables for static images

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -14,7 +14,7 @@ import com.airbnb.lottie.LottieImageAsset;
 import com.airbnb.lottie.utils.Logger;
 import com.airbnb.lottie.utils.Utils;
 
-import java.io.Exception;
+import java.lang.Exception;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;

--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -14,6 +14,7 @@ import com.airbnb.lottie.LottieImageAsset;
 import com.airbnb.lottie.utils.Logger;
 import com.airbnb.lottie.utils.Utils;
 
+import java.io.Exception;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -114,7 +115,7 @@ public class ImageAssetManager {
           bitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
           return putBitmap(id, bitmap);
         }
-      } catch (IOException e) {
+      } catch (Exception e) {
         Logger.warning("Unable to open resource.", e);
       }
     }

--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -102,21 +102,19 @@ public class ImageAssetManager {
       return putBitmap(id, bitmap);
     }
 
-    //if no images folder given assume drawable res
+    // If no images folder given, try loading from a drawable resource.
     if (TextUtils.isEmpty(imagesFolder)) {
       try
       {
         int drawableId = context.getResources().getIdentifier(filename, "drawable", context.getPackageName())
-        if(drawableId != -1)
+        if (drawableId != -1)
         {
-          //we dont pass "opts" we rely on system scaling drawables
+          // We don't pass BitmapFactor.Options because we rely on system scaling drawables.
           bitmap = BitmapFactory.decodeResource(context.getResources(), drawableId);
           bitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
           return putBitmap(id, bitmap);
         }
-      }
-      catch (Exception e) 
-      {
+      } catch (IOException e) {
         Logger.warning("Unable to open resource.", e);
       }
     }

--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -102,6 +102,25 @@ public class ImageAssetManager {
       return putBitmap(id, bitmap);
     }
 
+    //if no images folder given assume drawable res
+    if (TextUtils.isEmpty(imagesFolder)) {
+      try
+      {
+        int drawableId = context.getResources().getIdentifier(filename, "drawable", context.getPackageName())
+        if(drawableId != -1)
+        {
+          //we dont pass "opts" we rely on system scaling drawables
+          bitmap = BitmapFactory.decodeResource(context.getResources(), drawableId);
+          bitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
+          return putBitmap(id, bitmap);
+        }
+      }
+      catch (Exception e) 
+      {
+        Logger.warning("Unable to open resource.", e);
+      }
+    }
+    
     InputStream is;
     try {
       if (TextUtils.isEmpty(imagesFolder)) {

--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -106,7 +106,7 @@ public class ImageAssetManager {
     if (TextUtils.isEmpty(imagesFolder)) {
       try
       {
-        int drawableId = context.getResources().getIdentifier(filename, "drawable", context.getPackageName())
+        int drawableId = context.getResources().getIdentifier(filename, "drawable", context.getPackageName());
         if (drawableId != -1)
         {
           // We don't pass BitmapFactor.Options because we rely on system scaling drawables.


### PR DESCRIPTION
for ios lottile will load static images by @x2 @x3
on android for the system to automatically load the scaled image they need to be in a flat directory structure under res/drawable res/drawable-hdpi etc...

this PR assumes if image asset folder is not set (which is a no-op usually and throws an exception) then user wants to load images from resources as it has a flat structure (no sub directories allowed for drawables)
it will then load a bitmap from the drawable
