### PR TITLE
Ensure ImageView updates Drawable bounds when not using LottieAnimationView

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -489,11 +489,6 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
       return;
     }
 
-    // If you set a different composition on the view, the bounds will not update unless
-    // the drawable is different than the original.
-    setImageDrawable(null);
-    setImageDrawable(lottieDrawable);
-
     // This is needed to makes sure that the animation is properly played/paused for the current visibility state.
     // It is possible that the drawable had a lazy composition task to play the animation but this view subsequently
     // became invisible. Comment this out and run the espresso tests to see a failing test.

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -231,14 +231,10 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
 
     composition.setPerformanceTrackingEnabled(performanceTrackingEnabled);
 
-    // Prior to Marshmallow, ImageView would not update a drawable's width and height
-    // when it was invalidated. Because a LottieDrawable's width and height can change
-    // when a new composition is set, this can lead to an ImageView having the wrong
-    // cached width and height for this drawable.
-    // ImageView updates the builds on every invalidation on Marshmallow and above.
-    // https://android.googlesource.com/platform/frameworks/base/+/8473f5a768a1eafda92c81d208c00db334dfa9d4%5E%21/#F0
+    // Ensure that ImageView updates the drawable width/height so it can
+    // properly calculate its drawable matrix.
     Callback callback = getCallback();
-    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1 && callback instanceof ImageView) {
+    if (callback instanceof ImageView) {
       ((ImageView) callback).setImageDrawable(null);
       ((ImageView) callback).setImageDrawable(this);
     }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -231,6 +231,18 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
 
     composition.setPerformanceTrackingEnabled(performanceTrackingEnabled);
 
+    // Prior to Marshmallow, ImageView would not update a drawable's width and height
+    // when it was invalidated. Because a LottieDrawable's width and height can change
+    // when a new composition is set, this can lead to an ImageView having the wrong
+    // cached width and height for this drawable.
+    // ImageView updates the builds on every invalidation on Marshmallow and above.
+    // https://android.googlesource.com/platform/frameworks/base/+/8473f5a768a1eafda92c81d208c00db334dfa9d4%5E%21/#F0
+    Callback callback = getCallback();
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1 && callback instanceof ImageView) {
+      ((ImageView) callback).setImageDrawable(null);
+      ((ImageView) callback).setImageDrawable(this);
+    }
+
     return true;
   }
 


### PR DESCRIPTION
Fixes https://github.com/airbnb/lottie-android/issues/1492