### PR TITLE
[1523] Add support for default styles to LottieAnimationView

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -16,6 +16,7 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
 
+import androidx.annotation.AttrRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.FloatRange;
 import androidx.annotation.MainThread;
@@ -122,21 +123,21 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
 
   public LottieAnimationView(Context context) {
     super(context);
-    init(null);
+    init(null, R.attr.lottieAnimationViewStyle);
   }
 
   public LottieAnimationView(Context context, AttributeSet attrs) {
     super(context, attrs);
-    init(attrs);
+    init(attrs, R.attr.lottieAnimationViewStyle);
   }
 
   public LottieAnimationView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
-    init(attrs);
+    init(attrs, defStyleAttr);
   }
 
-  private void init(@Nullable AttributeSet attrs) {
-    TypedArray ta = getContext().obtainStyledAttributes(attrs, R.styleable.LottieAnimationView);
+  private void init(@Nullable AttributeSet attrs, @AttrRes int defStyleAttr) {
+    TypedArray ta = getContext().obtainStyledAttributes(attrs, R.styleable.LottieAnimationView, defStyleAttr, 0);
     if (!isInEditMode()) {
       cacheComposition = ta.getBoolean(R.styleable.LottieAnimationView_lottie_cacheComposition, true);
       boolean hasRawRes = ta.hasValue(R.styleable.LottieAnimationView_lottie_rawRes);

--- a/lottie/src/main/res/values/attrs.xml
+++ b/lottie/src/main/res/values/attrs.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <attr name="lottieAnimationViewStyle" format="reference" />
+
     <declare-styleable name="LottieAnimationView">
         <attr name="lottie_fileName" format="string" />
         <attr name="lottie_rawRes" format="reference" />


### PR DESCRIPTION
Fixes #1523, with an enhancement.

### Issue description

The issue was that the `defStyleAttr` would not be respected - the following class would compile, but `R.attr.heartViewStyle` would be ignored:

```kotlin
class HeartView(context: Context, attrs: AttributeSet)
    : LottieAnimationView(context, attrs, R.attr.heartViewStyle)
```

This meant that if we had a style:

```xml
<style name="Widget.LottieSample.HeartView">
    <item name="lottie_autoPlay">true</item>
    <item name="lottie_loop">true</item>
    <item name="lottie_url">https://raw.githubusercontent.com/airbnb/lottie-android/master/LottieSample/src/main/res/raw/heart.json</item>
</style>
```

we'd need to apply it explicitly in the layout each time we used it to a `LottieAnimationView` (or `HeartView`, but at this stage, there's no need for `HeartView` to exist - it doesn't do anything):

```xml
<com.airbnb.lottie.LottieAnimationView
    style="@style/Widget.LottieSample.HeartView"
    android:layout_width="256dp"
    android:layout_height="256dp"
    android:layout_gravity="center" />
```

### Solving the issue

After delegating `defStyleAttr` to the `init` function, and passing it to the `context.obtainedStyledAttributes` call, we're able to do this (note, there's no explicit style on this view):

```xml
<com.airbnb.lottie.samples.HeartView
    android:layout_width="256dp"
    android:layout_height="256dp"
    android:layout_gravity="center" />
```

as long as we set the `heartViewStyle` attribute in our application theme:

```xml
<style name="Theme.LottieSample" parent="Theme.AppCompat.Light.NoActionBar">
    ...
    <item name="heartViewStyle">@style/Widget.LottieSample.HeartView</item>
</style>

<style name="Widget.LottieSample.HeartView">
    <item name="lottie_autoPlay">true</item>
    <item name="lottie_loop">true</item>
    <item name="lottie_url">https://raw.githubusercontent.com/airbnb/lottie-android/master/LottieSample/src/main/res/raw/heart.json</item>
</style>
...
```

so every time we use `HeartView`, it'll use the correct style by default, across the app.

### Enhancing our solution

The addition that isn't covered in the original issue is adding a default style attribute for `LottieAnimationView` in the library, `R.attr.lottieAnimationViewStyle`.

This allows us to set default Lottie attributes across our app, for example the `autoPlay` and `loop` properties:

```xml
<style name="Theme.LottieSample" parent="Theme.AppCompat.Light.NoActionBar">
    ...
    <item name="lottieAnimationViewStyle">@style/Widget.LottieSample.LottieAnimationView</item>
</style>

<style name="Widget.LottieSample.LottieAnimationView" parent="android:Widget">
    <item name="lottie_autoPlay">true</item>
    <item name="lottie_loop">true</item>
</style>
```

such that in our layouts, we'd only need to specify the url, and **we wouldn't _need_ to use a custom view to do it**:

```xml
<com.airbnb.lottie.LottieAnimationView
    android:layout_width="256dp"
    android:layout_height="256dp"
    android:layout_gravity="center"
    app:lottie_url="https://raw.githubusercontent.com/airbnb/lottie-android/master/LottieSample/src/main/res/raw/lottielogo.json" />

<com.airbnb.lottie.LottieAnimationView
    android:layout_width="256dp"
    android:layout_height="256dp"
    android:layout_gravity="center"
    app:lottie_url="https://raw.githubusercontent.com/airbnb/lottie-android/master/LottieSample/src/main/res/raw/heart.json" />
```

**We can still override these properties in our layouts, if the default isn't suitable for all cases**. And this is what the above looks like:

![lottie](https://user-images.githubusercontent.com/2678555/75442321-22420400-5957-11ea-8cb8-a9dbb7ed549b.gif)

This solution works alongside any custom views too - so if you want a `HeartView` (or a `LoadingIndicatorView`) where you don't have to specify _any_ Lottie attributes - but most of the time, it's ok to use the vanilla `LottieAnimationView` because you're not reusing that particular icon, you can (the GIF looks the same with this layout and theme setup):

```xml
<com.airbnb.lottie.LottieAnimationView
    android:layout_width="256dp"
    android:layout_height="256dp"
    android:layout_gravity="center"
    app:lottie_url="https://raw.githubusercontent.com/airbnb/lottie-android/master/LottieSample/src/main/res/raw/lottielogo.json" />

<com.airbnb.lottie.samples.HeartView
    android:layout_width="256dp"
    android:layout_height="256dp"
    android:layout_gravity="center" />
```

where we've refactored `Widget.LottieSample.Heart` to extend from our default `Widget.LottieSample.LottieAnimationView` style, so that it also has the `autoPlay` and `loop` properties:

```xml
<style name="Theme.LottieSample" parent="Theme.AppCompat.Light.NoActionBar">
    ...
    <item name="lottieAnimationViewStyle">@style/Widget.LottieSample.LottieAnimationView</item>
    <item name="heartViewStyle">@style/Widget.LottieSample.LottieAnimationView.HeartView</item>
</style>

<style name="Widget.LottieSample.LottieAnimationView" parent="android:Widget">
    <item name="lottie_autoPlay">true</item>
    <item name="lottie_loop">true</item>
</style>

<style name="Widget.LottieSample.LottieAnimationView.HeartView">
    <!-- inherits autoPlay and loop from the parent style -->
    <item name="lottie_url">https://raw.githubusercontent.com/airbnb/lottie-android/master/LottieSample/src/main/res/raw/heart.json</item>
</style>
```
