### PR TITLE
disable hardware rendering for Android 7 to avoid native crashes in l…

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -1064,6 +1064,8 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
           useHardwareLayer = false;
         } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
           useHardwareLayer = false;
+        } else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N || Build.VERSION.SDK_INT == Build.VERSION_CODES.N_MR1) {
+          useHardwareLayer = false;
         }
         layerType = useHardwareLayer ? LAYER_TYPE_HARDWARE : LAYER_TYPE_SOFTWARE;
         break;


### PR DESCRIPTION
…ibhwui.so and libc.so

In my company I work on an app that serves over one million users.
We saw a sharp increase in our crash rates due to native libhwui.so / libc.so crash almost exclusively in Android 7 versions.
After reading [this](https://github.com/airbnb/lottie-android/issues/1453) and similar pages, I set software render mode on all of our LottieAnimationViews for Android 7, and this crash was gone. 