### PR TITLE
Fix scaling and tracking for dynamic text

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
@@ -116,7 +116,7 @@ public class TextLayer extends BaseLayer {
   void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha) {
     canvas.save();
     if (!lottieDrawable.useTextGlyphs()) {
-      canvas.setMatrix(parentMatrix);
+      canvas.concat(parentMatrix);
     }
     DocumentData documentData = textAnimation.getValue();
     Font font = composition.getFonts().get(documentData.fontName);
@@ -268,6 +268,8 @@ public class TextLayer extends BaseLayer {
       String textLine = textLines.get(l);
       float textLineWidth = strokePaint.measureText(textLine);
 
+      canvas.save();
+
       // Apply horizontal justification
       applyJustification(documentData.justification, canvas, textLineWidth);
 
@@ -280,7 +282,7 @@ public class TextLayer extends BaseLayer {
       drawFontTextLine(textLine, documentData, canvas, parentScale);
 
       // Reset canvas
-      canvas.setMatrix(parentMatrix);
+      canvas.restore();
     }
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
@@ -260,13 +260,23 @@ public class TextLayer extends BaseLayer {
     // Line height
     float lineHeight = documentData.lineHeight * Utils.dpScale();
 
+    // Calculate tracking
+    float tracking = documentData.tracking / 10f;
+    if (trackingCallbackAnimation != null) {
+      tracking += trackingCallbackAnimation.getValue();
+    } else if (trackingAnimation != null) {
+      tracking += trackingAnimation.getValue();
+    }
+    tracking = tracking * Utils.dpScale() * textSize / 100.0f;
+
     // Split full text in multiple lines
     List<String> textLines = getTextLines(text);
     int textLineCount = textLines.size();
     for (int l = 0; l < textLineCount; l++) {
 
       String textLine = textLines.get(l);
-      float textLineWidth = strokePaint.measureText(textLine);
+      // We have to manually add the tracking between characters as the strokePaint ignores it
+      float textLineWidth = strokePaint.measureText(textLine) + (textLine.length() - 1) * tracking;
 
       canvas.save();
 
@@ -279,7 +289,7 @@ public class TextLayer extends BaseLayer {
       canvas.translate(0, translateY);
 
       // Draw each line
-      drawFontTextLine(textLine, documentData, canvas, parentScale);
+      drawFontTextLine(textLine, documentData, canvas, tracking);
 
       // Reset canvas
       canvas.restore();
@@ -294,20 +304,13 @@ public class TextLayer extends BaseLayer {
     return Arrays.asList(textLinesArray);
   }
 
-  private void drawFontTextLine(String text, DocumentData documentData, Canvas canvas, float parentScale) {
+  private void drawFontTextLine(String text, DocumentData documentData, Canvas canvas, float tracking) {
     for (int i = 0; i < text.length(); ) {
       String charString = codePointToString(text, i);
       i += charString.length();
       drawCharacterFromFont(charString, documentData, canvas);
-      float charWidth = fillPaint.measureText(charString, 0, 1);
-      // Add tracking
-      float tracking = documentData.tracking / 10f;
-      if (trackingCallbackAnimation != null) {
-        tracking += trackingCallbackAnimation.getValue();
-      } else if (trackingAnimation != null) {
-        tracking += trackingAnimation.getValue();
-      }
-      float tx = charWidth + tracking * parentScale;
+      float charWidth = fillPaint.measureText(charString);
+      float tx = charWidth + tracking;
       canvas.translate(tx, 0);
     }
   }


### PR DESCRIPTION
Close #1183. Close #1310.

This has a couple of related bugfixes.

1. Fix the scale/positioning of the text relative to the parent (from PR #1583, thanks @pikaMouse)
1. Include text tracking values in the line width used for text alignment
1. Scale the text tracking values based on the font size rather than the parent size (parent size adjustment is already handled when we're calculating tracking values)
1. Include all bytes for multibyte characters when calculating canvas offsets for characters.

From #1183, here's the updated test animation result with the text correctly centered between the lines:

<img width="307" alt="Screen Shot 2020-09-30 at 11 02 54 AM" src="https://user-images.githubusercontent.com/519038/94703352-bc629400-030c-11eb-9c76-fc64f38e4fe3.png">

And here's the before and after for the same sample with some 🦁 emojis added in to show multibyte character measurement:

Before:
<img width="324" alt="Screen Shot 2020-09-30 at 11 10 47 AM" src="https://user-images.githubusercontent.com/519038/94704299-c33dd680-030d-11eb-80c6-f5a03df08128.png">

After:
<img width="325" alt="Screen Shot 2020-09-30 at 11 11 43 AM" src="https://user-images.githubusercontent.com/519038/94704268-bb7e3200-030d-11eb-9c63-e447b42bb467.png">



