### PR TITLE
add support for dotLottie 

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -487,7 +487,7 @@ public class LottieCompositionFactory {
     try {
       BufferedSource peek = inputSource.peek();
       for (byte b: MAGIC) {
-        if(peek.readByte()!=b)
+        if(peek.readByte() != b)
           return false;
       }
       peek.close();

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -9,6 +9,7 @@ import android.graphics.BitmapFactory;
 import com.airbnb.lottie.model.LottieCompositionCache;
 import com.airbnb.lottie.parser.LottieCompositionMoshiParser;
 import com.airbnb.lottie.parser.moshi.JsonReader;
+import com.airbnb.lottie.utils.Logger;
 import com.airbnb.lottie.utils.Utils;
 
 import org.json.JSONObject;
@@ -493,7 +494,7 @@ public class LottieCompositionFactory {
       peek.close();
       return true;
     } catch (Exception e) {
-      L.error(e, "Failed to check zip file header")
+      Logger.error("Failed to check zip file header", e);
       return false;
     }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -262,7 +262,7 @@ public class LottieCompositionFactory {
   public static LottieResult<LottieComposition> fromRawResSync(Context context, @RawRes int rawRes, @Nullable String cacheKey) {
     try {
       BufferedSource source = Okio.buffer(source(context.getResources().openRawResource(rawRes)));
-      if(isZipCompressed(source)) {
+      if (isZipCompressed(source)) {
         return fromZipStreamSync(new ZipInputStream(source.inputStream()), cacheKey);
       }
       return fromJsonInputStreamSync(source.inputStream(), cacheKey);

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -486,7 +486,7 @@ public class LottieCompositionFactory {
 
     try {
       BufferedSource peek = inputSource.peek();
-      for(byte b: MAGIC) {
+      for (byte b: MAGIC) {
         if(peek.readByte()!=b)
           return false;
       }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -188,13 +188,7 @@ public class LottieCompositionFactory {
   @WorkerThread
   public static LottieResult<LottieComposition> fromAssetSync(Context context, String fileName, @Nullable String cacheKey) {
     try {
-      if(fileName.endsWith(".lottie")) {
-        // in case the .lottie is just a renamed .json
-        boolean isZip = isZipCompressed(context.getAssets().open(fileName));
-        if(isZip) {
-          return fromZipStreamSync(new ZipInputStream(context.getAssets().open(fileName)), cacheKey);
-        }
-      } else if (fileName.endsWith(".zip")) {
+      if (fileName.endsWith(".zip") || fileName.endsWith(".lottie")) {
         return fromZipStreamSync(new ZipInputStream(context.getAssets().open(fileName)), cacheKey);
       }
       return fromJsonInputStreamSync(context.getAssets().open(fileName), cacheKey);
@@ -266,7 +260,7 @@ public class LottieCompositionFactory {
   @WorkerThread
   public static LottieResult<LottieComposition> fromRawResSync(Context context, @RawRes int rawRes, @Nullable String cacheKey) {
     try {
-      // performance note: raw res opened twice isn't exactly idea,
+      // performance note: raw res opened twice isn't exactly ideal,
       // but it's the only way we can tell if the res is a .zip or not
       boolean isZip = isZipCompressed(context.getResources().openRawResource(rawRes));
       if(isZip) {

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -493,7 +493,7 @@ public class LottieCompositionFactory {
       peek.close();
       return true;
     } catch (Exception e) {
-      e.printStackTrace();
+      L.error(e, "Failed to check zip file header")
       return false;
     }
 

--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
@@ -108,7 +108,7 @@ public class NetworkFetcher {
       // in the result which is more useful than failing here.
       contentType = "application/json";
     }
-    if (contentType.contains("application/zip")) {
+    if (contentType.contains("application/zip") || url.contains(".lottie")) {
       Logger.debug("Handling zip response.");
       extension = FileExtension.ZIP;
       result = fromZipStream(url, inputStream, cacheKey);

--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
@@ -108,7 +108,7 @@ public class NetworkFetcher {
       // in the result which is more useful than failing here.
       contentType = "application/json";
     }
-    if (contentType.contains("application/zip") || url.contains(".lottie")) {
+    if (contentType.contains("application/zip") || url.split("\\?")[0].endsWith(".lottie")) {
       Logger.debug("Handling zip response.");
       extension = FileExtension.ZIP;
       result = fromZipStream(url, inputStream, cacheKey);


### PR DESCRIPTION
Fix parsing .lottie files
the dotLottie format  (dotlottie.io) is a zip file with animation.json bundled along with image resources, and manifest

**Changes**
* update zipStreamSync() to handle dotLottie use case
  * ignore manifest.json otherwise lottie will try to use it

* update network loader to check for .lottie and treat it as a .zip

* add support for .lottie and in rawRes
  * use magic header to determine files and use zipStreamSync() instead of fromJsonSync()
  * this has the bonus side effect of allowing .zip files in rawRes as well (which doesn't appear to have been supported before)
