### PR TITLE
[Compose] Removed unnecessary dependencies

### DIFF
--- a/lottie-compose/build.gradle
+++ b/lottie-compose/build.gradle
@@ -40,7 +40,5 @@ android {
 dependencies {
   api project(':lottie')
   implementation "androidx.compose.ui:ui:$composeVersion"
-  implementation "androidx.compose.material:material:$composeVersion"
-  implementation "androidx.compose.material:material-icons-extended:$composeVersion"
   implementation 'androidx.lifecycle:lifecycle-common-java8:2.3.0-beta01'
 }


### PR DESCRIPTION
`material` and `material-icons-android` these dependencies contain a giant number of icons which are not used in `lottie-compose` module, so I just removed them to reduce apk file size.