### PR TITLE
Display last animated text value

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/TextKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/TextKeyframeAnimation.java
@@ -11,6 +11,9 @@ public class TextKeyframeAnimation extends KeyframeAnimation<DocumentData> {
   }
 
   @Override DocumentData getValue(Keyframe<DocumentData> keyframe, float keyframeProgress) {
-    return keyframe.startValue;
+    if (keyframeProgress != 1.0f || keyframe.endValue == null)
+      return keyframe.startValue;
+    else
+      return keyframe.endValue;
   }
 }


### PR DESCRIPTION
When using animated text, the last value was not shown. Issue can be reproduce with this json: https://assets7.lottiefiles.com/packages/lf20_fteywrno.json