### PR TITLE
Fail quietly if ImageAssetManager fails to decode a bitmap

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -113,7 +113,12 @@ public class ImageAssetManager {
       Logger.warning("Unable to open asset.", e);
       return null;
     }
-    bitmap = BitmapFactory.decodeStream(is, null, opts);
+    try {
+      bitmap = BitmapFactory.decodeStream(is, null, opts);
+    } catch (IllegalArgumentException e) {
+      Logger.warning("Unable to decode image.", e);
+      return null;
+    }
     bitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
     return putBitmap(id, bitmap);
   }


### PR DESCRIPTION
Fixes #1718 