### PR TITLE
[Compose] Add Snapshot Dependency Documentation

### DIFF
--- a/CHANGELOG_COMPOSE.md
+++ b/CHANGELOG_COMPOSE.md
@@ -1,3 +1,9 @@
+#### Note: For the time being, we won't provide numbered releases for every new Jetpack Compose
+version. Check out our [snapshot builds](https://github.com/airbnb/lottie/blob/master/android-compose.md#getting-started) instead.
+
+# 1.0.0-alpha06-SNAPSHOT
+* Compatible with Jetpack Compose Alpha 11
+
 # 1.0.0-alpha05
 * Jetpack Compose Alpha 9
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ dependencies {
 The latest Lottie version is:
 ![lottieVersion](https://maven-badges.herokuapp.com/maven-central/com.airbnb.android/lottie/badge.svg)
 
+The latest stable [Lottie-Compose](http://airbnb.io/lottie/#/android-compose) version is:
+![lottieVersion](https://maven-badges.herokuapp.com/maven-central/com.airbnb.android/lottie-compose/badge.svg)
+Click [here](http://airbnb.io/lottie/#/android-compose) for more information on Lottie-Compose.
+
 Lottie 2.8.0 and above only supports projects that have been migrated to [androidx](https://developer.android.com/jetpack/androidx/). For more information, read Google's [migration guide](https://developer.android.com/jetpack/androidx/migrate).
 
 # Contributing


### PR DESCRIPTION
Referring to #1733, also see https://github.com/airbnb/lottie/pull/151

Adds a bit of information about how to include lottie-compose snapshots.

CC @gpeal