### PR TITLE
Added override for system animations enabled behavior

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -219,9 +219,11 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
       setRenderMode(RenderMode.values()[renderModeOrdinal]);
     }
 
+    boolean forceAnimationEnabled = ta.getBoolean(R.styleable.LottieAnimationView_lottie_forceAnimationsEnabled, false);
+
     ta.recycle();
 
-    lottieDrawable.setSystemAnimationsAreEnabled(Utils.getAnimationScale(getContext()) != 0f);
+    lottieDrawable.setSystemAnimationsAreEnabled(Utils.getAnimationScale(getContext()) != 0f || forceAnimationEnabled);
 
     enableOrDisableHardwareLayer();
     isInitialized = true;

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -361,7 +361,7 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
   }
 
   /**
-   * Allows to ignore system animations settings therefore allowing animations to run even if they are disabled.
+   * Allows ignoring system animations settings, therefore allowing animations to run even if they are disabled.
    *
    * Defaults to false.
    *

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -219,11 +219,16 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
       setRenderMode(RenderMode.values()[renderModeOrdinal]);
     }
 
-    boolean forceAnimationEnabled = ta.getBoolean(R.styleable.LottieAnimationView_lottie_forceAnimationsEnabled, false);
+    setIgnoreDisabledSystemAnimations(
+        ta.getBoolean(
+            R.styleable.LottieAnimationView_lottie_ignoreDisabledSystemAnimations,
+            false
+        )
+    );
 
     ta.recycle();
 
-    lottieDrawable.setSystemAnimationsAreEnabled(Utils.getAnimationScale(getContext()) != 0f || forceAnimationEnabled);
+    lottieDrawable.setSystemAnimationsAreEnabled(Utils.getAnimationScale(getContext()) != 0f);
 
     enableOrDisableHardwareLayer();
     isInitialized = true;
@@ -353,6 +358,17 @@ import static com.airbnb.lottie.RenderMode.HARDWARE;
       wasAnimatingWhenDetached = true;
     }
     super.onDetachedFromWindow();
+  }
+
+  /**
+   * Allows to ignore system animations settings therefore allowing animations to run even if they are disabled.
+   *
+   * Defaults to false.
+   *
+   * @param ignore if true animations will run even when they are disabled in the system settings.
+   */
+  public void setIgnoreDisabledSystemAnimations(boolean ignore) {
+    lottieDrawable.setIgnoreDisabledSystemAnimations(ignore);
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -59,9 +59,11 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   private LottieComposition composition;
   private final LottieValueAnimator animator = new LottieValueAnimator();
   private float scale = 1f;
-  private boolean animationsEnabled = true;
+
+  //Call animationsEnabled() instead of using these fields directly
   private boolean systemAnimationsEnabled = true;
   private boolean ignoreSystemAnimationsDisabled = false;
+
   private boolean safeMode = false;
 
   private final ArrayList<LazyCompositionTask> lazyCompositionTasks = new ArrayList<>();
@@ -447,10 +449,10 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       return;
     }
 
-    if (animationsEnabled || getRepeatCount() == 0) {
+    if (animationsEnabled() || getRepeatCount() == 0) {
       animator.playAnimation();
     }
-    if (!animationsEnabled) {
+    if (!animationsEnabled()) {
       setFrame((int) (getSpeed() < 0 ? getMinFrame() : getMaxFrame()));
       animator.endAnimation();
     }
@@ -478,10 +480,10 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       return;
     }
 
-    if (animationsEnabled || getRepeatCount() == 0) {
+    if (animationsEnabled() || getRepeatCount() == 0) {
       animator.resumeAnimation();
     }
-    if (!animationsEnabled) {
+    if (!animationsEnabled()) {
       setFrame((int) (getSpeed() < 0 ? getMinFrame() : getMaxFrame()));
       animator.endAnimation();
     }
@@ -868,9 +870,12 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     return animator.isRunning();
   }
 
+  private boolean animationsEnabled() {
+    return systemAnimationsEnabled || ignoreSystemAnimationsDisabled;
+  }
+
   void setSystemAnimationsAreEnabled(Boolean areEnabled) {
     systemAnimationsEnabled = areEnabled;
-    animationsEnabled = systemAnimationsEnabled || ignoreSystemAnimationsDisabled;
   }
 
 // </editor-fold>
@@ -884,7 +889,6 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setIgnoreDisabledSystemAnimations(boolean ignore) {
     ignoreSystemAnimationsDisabled = ignore;
-    animationsEnabled = systemAnimationsEnabled || ignoreSystemAnimationsDisabled;
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -59,7 +59,9 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   private LottieComposition composition;
   private final LottieValueAnimator animator = new LottieValueAnimator();
   private float scale = 1f;
+  private boolean animationsEnabled = true;
   private boolean systemAnimationsEnabled = true;
+  private boolean ignoreSystemAnimationsDisabled = false;
   private boolean safeMode = false;
 
   private final ArrayList<LazyCompositionTask> lazyCompositionTasks = new ArrayList<>();
@@ -445,10 +447,10 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       return;
     }
 
-    if (systemAnimationsEnabled || getRepeatCount() == 0) {
+    if (animationsEnabled || getRepeatCount() == 0) {
       animator.playAnimation();
     }
-    if (!systemAnimationsEnabled) {
+    if (!animationsEnabled) {
       setFrame((int) (getSpeed() < 0 ? getMinFrame() : getMaxFrame()));
       animator.endAnimation();
     }
@@ -476,10 +478,10 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       return;
     }
 
-    if (systemAnimationsEnabled || getRepeatCount() == 0) {
+    if (animationsEnabled || getRepeatCount() == 0) {
       animator.resumeAnimation();
     }
-    if (!systemAnimationsEnabled) {
+    if (!animationsEnabled) {
       setFrame((int) (getSpeed() < 0 ? getMinFrame() : getMaxFrame()));
       animator.endAnimation();
     }
@@ -866,11 +868,24 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     return animator.isRunning();
   }
 
-  public void setSystemAnimationsAreEnabled(Boolean areEnabled) {
+  void setSystemAnimationsAreEnabled(Boolean areEnabled) {
     systemAnimationsEnabled = areEnabled;
+    animationsEnabled = systemAnimationsEnabled || ignoreSystemAnimationsDisabled;
   }
 
 // </editor-fold>
+
+  /**
+   * Allows to ignore system animations settings therefore allowing animations to run even if they are disabled.
+   *
+   * Defaults to false.
+   *
+   * @param ignore if true animations will run even when they are disabled in the system settings.
+   */
+  public void setIgnoreDisabledSystemAnimations(boolean ignore) {
+    ignoreSystemAnimationsDisabled = ignore;
+    animationsEnabled = systemAnimationsEnabled || ignoreSystemAnimationsDisabled;
+  }
 
   /**
    * Set the scale on the current composition. The only cost of this function is re-rendering the

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -866,7 +866,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     return animator.isRunning();
   }
 
-  void setSystemAnimationsAreEnabled(Boolean areEnabled) {
+  public void setSystemAnimationsAreEnabled(Boolean areEnabled) {
     systemAnimationsEnabled = areEnabled;
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -876,7 +876,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
 // </editor-fold>
 
   /**
-   * Allows to ignore system animations settings therefore allowing animations to run even if they are disabled.
+   * Allows ignoring system animations settings, therefore allowing animations to run even if they are disabled.
    *
    * Defaults to false.
    *

--- a/lottie/src/main/res/values/attrs.xml
+++ b/lottie/src/main/res/values/attrs.xml
@@ -21,7 +21,7 @@
         <attr name="lottie_scale" format="float" />
         <attr name="lottie_speed" format="float" />
         <attr name="lottie_cacheComposition" format="boolean" />
-        <attr name="lottie_forceAnimationsEnabled" format="boolean" />
+        <attr name="lottie_ignoreDisabledSystemAnimations" format="boolean" />
         <!-- These values must be kept in sync with the RenderMode enum -->
         <attr name="lottie_renderMode" format="enum">
             <enum name="automatic" value="0" />

--- a/lottie/src/main/res/values/attrs.xml
+++ b/lottie/src/main/res/values/attrs.xml
@@ -21,6 +21,7 @@
         <attr name="lottie_scale" format="float" />
         <attr name="lottie_speed" format="float" />
         <attr name="lottie_cacheComposition" format="boolean" />
+        <attr name="lottie_forceAnimationsEnabled" format="boolean" />
         <!-- These values must be kept in sync with the RenderMode enum -->
         <attr name="lottie_renderMode" format="enum">
             <enum name="automatic" value="0" />


### PR DESCRIPTION
Good morning or afternoon, Lottie!

I created this small PR for a use case I currently have in my project. Essentially, we have a fullscreen animation that have loading and success states. When loading finishes, we play out final state of the animation and listen for Animator.AnimatorListener#onAnimationEnd to dismiss the screen.

Obviously, if user opted to disable animations the screen is stuck, because the listener method is never invoked (we add it just before playing the final state of the animation) and therefore screen is never dismissed. 

This PR provides a possibility to override current behaviour (which is just looking if animations are disabled in Settings) with custom flag in XML (false by default, so behaviour won't change) and makes LottieDrawable#setSystemAnimationsAreEnabled public so it can be overridden from the code. 

I haven't found any test cases that would use API I've changed and didn't see docs I should modify, however if I missed that please do tell me.