### PR TITLE
[Compose] Swap Modifier order

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
@@ -115,9 +115,8 @@ fun LottieAnimation(
     if (composition == null || composition.duration == 0f) return
 
     Canvas(
-        modifier = Modifier
+        modifier = modifier
             .maintainAspectRatio(composition)
-            .then(modifier)
     ) {
         drawIntoCanvas { canvas ->
             drawable.progress = state.progress


### PR DESCRIPTION
This makes LottieAnimation modifiers behave as they are supposed to given the [Compose guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md)

Fixes #1761 