### PR TITLE
[Compose Sample] Add bitmaps and dummy bitmaps to the sample app

### DIFF
--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/player/PlayerPage.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/player/PlayerPage.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -29,6 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.airbnb.lottie.ImageAssetDelegate
 import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.compose.*
 import com.airbnb.lottie.sample.compose.BuildConfig
@@ -38,6 +40,7 @@ import com.airbnb.lottie.sample.compose.ui.Teal
 import com.airbnb.lottie.sample.compose.utils.drawBottomBorder
 import com.airbnb.lottie.sample.compose.utils.maybeBackground
 import com.airbnb.lottie.sample.compose.utils.maybeDrawBorder
+import com.airbnb.lottie.sample.compose.utils.toDummyBitmap
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
@@ -48,7 +51,13 @@ fun PlayerPage(
 ) {
     val backPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val compositionResult = rememberLottieComposition(spec)
-    val animationState = rememberLottieAnimationState(autoPlay = true, repeatCount = Integer.MAX_VALUE)
+    val dummyBitmapStrokeWidth = with(LocalDensity.current) { 3.dp.toPx() }
+    val imageAssetDelegate = remember(compositionResult) { ImageAssetDelegate { it.bitmap ?: it.toDummyBitmap(dummyBitmapStrokeWidth) }}
+    val animationState = rememberLottieAnimationState(
+        autoPlay = true,
+        repeatCount = Integer.MAX_VALUE,
+        imageAssetDelegate = imageAssetDelegate
+    )
     val scaffoldState = rememberScaffoldState()
     val outlineMasksAndMattes = remember { mutableStateOf(false) }
     val applyOpacityToLayers = remember { mutableStateOf(false) }

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/utils/BitmapUtils.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/utils/BitmapUtils.kt
@@ -1,0 +1,20 @@
+package com.airbnb.lottie.sample.compose.utils
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import com.airbnb.lottie.LottieImageAsset
+
+fun LottieImageAsset.toDummyBitmap(strokeWidth: Float): Bitmap {
+    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    val paint = Paint()
+    paint.color = Color.GRAY
+    paint.style = Paint.Style.STROKE
+    paint.strokeWidth = strokeWidth
+    canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paint)
+    canvas.drawLine(0f, 0f, width.toFloat(), height.toFloat(), paint)
+    canvas.drawLine(width.toFloat(), 0f, 0f, height.toFloat(), paint)
+    return bitmap
+}


### PR DESCRIPTION
Now, when an image is missing, it will be rendered with a gray box
![image](https://user-images.githubusercontent.com/1307745/116027982-0e516b00-a60b-11eb-9a4d-b12365994f63.png)
