### PR TITLE
[Compose] Added the ability to set dynamic properties

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
@@ -69,6 +69,8 @@ import com.airbnb.lottie.setImageAssetManager
  *                         features so it defaults to off. The only way to know if your animation will work
  *                         well with merge paths or not is to try it. If your animation has merge paths and
  *                         doesn't render correctly, please file an issue.
+ * @param dynamicProperties Allows you to change the properties of an animation dynamically. To use them, use
+ *                          [rememberLottieDynamicProperties]. Refer to its docs for more info.
  */
 @Composable
 fun LottieAnimation(
@@ -80,9 +82,11 @@ fun LottieAnimation(
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
     enableMergePaths: Boolean = false,
+    dynamicProperties: LottieDynamicProperties? = null,
 ) {
     val drawable = remember { LottieDrawable() }
     var imageAssetManager by remember { mutableStateOf<ImageAssetManager?>(null) }
+    var setDynamicProperties: LottieDynamicProperties? by remember { mutableStateOf(null) }
 
     if (composition == null || composition.duration == 0f) return Box(modifier)
 
@@ -104,6 +108,11 @@ fun LottieAnimation(
                 scale(size.width / composition.bounds.width().toFloat(), size.height / composition.bounds.height().toFloat(), Offset.Zero)
             }) {
                 drawable.composition = composition
+                if (dynamicProperties !== setDynamicProperties) {
+                    setDynamicProperties?.removeFrom(drawable)
+                    dynamicProperties?.addTo(drawable)
+                    setDynamicProperties = dynamicProperties
+                }
                 drawable.setOutlineMasksAndMattes(outlineMasksAndMattes)
                 drawable.isApplyingOpacityToLayersEnabled = applyOpacityToLayers
                 drawable.enableMergePathsForKitKatAndAbove(enableMergePaths)
@@ -133,6 +142,7 @@ fun LottieAnimation(
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
     enableMergePaths: Boolean = false,
+    dynamicProperties: LottieDynamicProperties? = null,
 ) {
     val composition by lottieComposition(compositionSpec)
     LottieAnimation(
@@ -144,6 +154,7 @@ fun LottieAnimation(
         outlineMasksAndMattes,
         applyOpacityToLayers,
         enableMergePaths,
+        dynamicProperties,
     )
 }
 
@@ -171,6 +182,7 @@ fun LottieAnimation(
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
     enableMergePaths: Boolean = false,
+    dynamicProperties: LottieDynamicProperties? = null,
 ) {
     val composition by lottieComposition(compositionSpec)
     LottieAnimation(
@@ -188,6 +200,7 @@ fun LottieAnimation(
         outlineMasksAndMattes,
         applyOpacityToLayers,
         enableMergePaths,
+        dynamicProperties,
     )
 }
 
@@ -214,6 +227,7 @@ fun LottieAnimation(
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
     enableMergePaths: Boolean = false,
+    dynamicProperties: LottieDynamicProperties? = null,
 ) {
     val progress by animateLottieComposition(
         composition,
@@ -234,6 +248,7 @@ fun LottieAnimation(
         outlineMasksAndMattes,
         applyOpacityToLayers,
         enableMergePaths,
+        dynamicProperties,
     )
 }
 

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieConstants.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieConstants.kt
@@ -1,0 +1,8 @@
+package com.airbnb.lottie.compose
+
+object LottieConstants {
+    /**
+     * Use with [animateLottieComposition#repetCount] to repeat forever.
+     */
+    const val RepeatForever = Integer.MAX_VALUE
+}

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieDynamicProperties.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieDynamicProperties.kt
@@ -1,0 +1,167 @@
+package com.airbnb.lottie.compose
+
+import android.graphics.ColorFilter
+import android.graphics.PointF
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import com.airbnb.lottie.LottieDrawable
+import com.airbnb.lottie.model.KeyPath
+import com.airbnb.lottie.value.LottieFrameInfo
+import com.airbnb.lottie.value.LottieValueCallback
+import com.airbnb.lottie.value.ScaleXY
+
+/**
+ * Use this function when you want to apply one or more dynamic properties to an animation.
+ * This takes a vararg of individual dynamic properties which should be created with [rememberLottieDynamicProperty].
+ *
+ * @see rememberLottieDynamicProperty
+ */
+@Composable
+fun rememberLottieDynamicProperties(
+    vararg properties: LottieDynamicProperty<*>,
+): LottieDynamicProperties {
+    @Suppress("UNCHECKED_CAST")
+    return remember(properties) {
+        val intProperties = properties.filter { it.property is Int } as List<LottieDynamicProperty<Int>>
+        val pointFProperties = properties.filter { it.property is PointF } as List<LottieDynamicProperty<PointF>>
+        val floatProperties = properties.filter { it.property is Float } as List<LottieDynamicProperty<Float>>
+        val scaleProperties = properties.filter { it.property is ScaleXY } as List<LottieDynamicProperty<ScaleXY>>
+        val colorFilterProperties = properties.filter { it.property is ColorFilter } as List<LottieDynamicProperty<ColorFilter>>
+        val intArrayProperties = properties.filter { it.property is IntArray } as List<LottieDynamicProperty<IntArray>>
+        LottieDynamicProperties(
+            intProperties,
+            pointFProperties,
+            floatProperties,
+            scaleProperties,
+            colorFilterProperties,
+            intArrayProperties,
+        )
+    }
+}
+
+/**
+ * Use this to create a single dynamic property for an animation.
+ *
+ * @param property should be one of [com.airbnb.lottie.LottieProperty].
+ * @param value the desired value to use as this property's value.
+ * @param keyPath the string parts of a [com.airbnb.lottie.model.KeyPath] that specify which animation element
+ *                the property resides on.
+ */
+@Composable
+fun <T> rememberLottieDynamicProperty(
+    property: T,
+    value: T,
+    vararg keyPath: String,
+): LottieDynamicProperty<T> {
+    val keyPathObj = remember(keyPath) { KeyPath(*keyPath) }
+    val callback: (LottieFrameInfo<T>) -> T = remember(value) { { value } }
+    val currentCallback by rememberUpdatedState(callback)
+    return remember(keyPathObj, property) {
+        LottieDynamicProperty(
+            keyPathObj,
+            property,
+            object : LottieValueCallback<T>() {
+                override fun getValue(frameInfo: LottieFrameInfo<T>): T {
+                    return currentCallback(frameInfo)
+                }
+            },
+        )
+    }
+}
+
+/**
+ * Use this to create a single dynamic property for an animation.
+ *
+ * @param property Should be one of [com.airbnb.lottie.LottieProperty].
+ * @param keyPath The string parts of a [com.airbnb.lottie.model.KeyPath] that specify which animation element
+ *                the property resides on.
+ * @param callback A callback that will be invoked during the drawing pass with current frame info. The frame
+ *                 info can be used to alter the property's value based on the original animation data or it
+ *                 can be completely ignored and an arbitrary value can be returned. In this case, you may want
+ *                 the overloaded version of this function that takes a static value instead of a callback.
+ */
+@Composable
+fun <T> rememberLottieDynamicProperty(
+    property: T,
+    vararg keyPath: String,
+    callback: (frameInfo: LottieFrameInfo<T>) -> T
+): LottieDynamicProperty<T> {
+    val keyPathObj = remember(keyPath) { KeyPath(*keyPath) }
+    val currentCallback by rememberUpdatedState(callback)
+    return remember(keyPathObj, property) {
+        LottieDynamicProperty(
+            keyPathObj,
+            property,
+            object : LottieValueCallback<T>() {
+                override fun getValue(frameInfo: LottieFrameInfo<T>): T {
+                    return currentCallback(frameInfo)
+                }
+            },
+        )
+    }
+}
+
+/**
+ * @see rememberLottieDynamicProperty
+ */
+class LottieDynamicProperty<T> internal constructor(
+    internal val keyPath: KeyPath,
+    internal val property: T,
+    internal val valueCallback: LottieValueCallback<T>,
+)
+
+/**
+ * @see rememberLottieDynamicProperties
+ */
+class LottieDynamicProperties internal constructor(
+    private val intProperties: List<LottieDynamicProperty<Int>>,
+    private val pointFProperties: List<LottieDynamicProperty<PointF>>,
+    private val floatProperties: List<LottieDynamicProperty<Float>>,
+    private val scaleProperties: List<LottieDynamicProperty<ScaleXY>>,
+    private val colorFilterProperties: List<LottieDynamicProperty<ColorFilter>>,
+    private val intArrayProperties: List<LottieDynamicProperty<IntArray>>,
+) {
+    internal fun addTo(drawable: LottieDrawable) {
+        intProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, p.valueCallback)
+        }
+        pointFProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, p.valueCallback)
+        }
+        floatProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, p.valueCallback)
+        }
+        scaleProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, p.valueCallback)
+        }
+        colorFilterProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, p.valueCallback)
+        }
+        intArrayProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, p.valueCallback)
+        }
+    }
+
+    internal fun removeFrom(drawable: LottieDrawable) {
+        intProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, null as LottieValueCallback<Int>?)
+        }
+        pointFProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, null as LottieValueCallback<PointF>?)
+        }
+        floatProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, null as LottieValueCallback<Float>?)
+        }
+        scaleProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, null as LottieValueCallback<ScaleXY>?)
+        }
+        colorFilterProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, null as LottieValueCallback<ColorFilter>?)
+        }
+        intArrayProperties.forEach { p ->
+            drawable.addValueCallback(p.keyPath, p.property, null as LottieValueCallback<IntArray>?)
+        }
+    }
+}

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/animateLottieComposition.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/animateLottieComposition.kt
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit
  * @param speed The speed the animation should play at. Numbers larger than one will speed it up.
  *              Numbers between 0 and 1 will slow it down. Numbers less than 0 will play it backwards.
  * @param repeatCount The number of times the animation should repeat before stopping. It must be
- *                    a positive number. [Integer.MAX_VALUE] can be used to repeat forever.
+ *                    a positive number. [LottieConstants.RepeatForever] can be used to repeat forever.
  * @param onRepeat An optional callback to be notified every time the animation repeats. Return whether
  *                 or not the animation should continue to repeat.
  * @param onFinished An optional callback that is invoked when animation completes. Note that the isPlaying

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -1024,7 +1024,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    * {@link #resolveKeyPath(KeyPath)} and will resolve it if it hasn't.
    */
   public <T> void addValueCallback(
-      final KeyPath keyPath, final T property, final LottieValueCallback<T> callback) {
+      final KeyPath keyPath, final T property, @Nullable final LottieValueCallback<T> callback) {
     if (compositionLayer == null) {
       lazyCompositionTasks.add(new LazyCompositionTask() {
         @Override

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/ComposeActivity.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/ComposeActivity.kt
@@ -17,10 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.*
 import com.airbnb.lottie.compose.LottieCompositionSpec
-import com.airbnb.lottie.sample.compose.examples.BasicUsageExamplesPage
-import com.airbnb.lottie.sample.compose.examples.ExamplesPage
-import com.airbnb.lottie.sample.compose.examples.NetworkExamplesPage
-import com.airbnb.lottie.sample.compose.examples.TransitionsExamplesPage
+import com.airbnb.lottie.sample.compose.examples.*
 import com.airbnb.lottie.sample.compose.lottiefiles.LottieFilesPage
 import com.airbnb.lottie.sample.compose.player.PlayerPage
 import com.airbnb.lottie.sample.compose.preview.PreviewPage
@@ -85,6 +82,7 @@ class ComposeActivity : AppCompatActivity() {
                         composable(Route.BasicUsageExamples.route) { BasicUsageExamplesPage() }
                         composable(Route.TransitionsExamples.route) { TransitionsExamplesPage() }
                         composable(Route.NetworkExamples.route) { NetworkExamplesPage() }
+                        composable(Route.DynamicPropertiesExamples.route) { DynamicPropertiesExamplesPage() }
                         composable(
                             Route.Player.fullRoute,
                             arguments = Route.Player.args

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/Route.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/Route.kt
@@ -22,6 +22,8 @@ sealed class Route(val route: String, val args: List<NamedNavArgument> = emptyLi
 
     object NetworkExamples : Route("network examples")
 
+    object DynamicPropertiesExamples : Route("dynamic properties examples")
+
     object Player : Route(
         "player",
         listOf(

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/examples/BasicUsageExamplesPage.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/examples/BasicUsageExamplesPage.kt
@@ -62,7 +62,7 @@ private fun Example1() {
 private fun Example2() {
     LottieAnimation(
         LottieCompositionSpec.RawRes(R.raw.heart),
-        repeatCount = Integer.MAX_VALUE,
+        repeatCount = LottieConstants.RepeatForever,
     )
 }
 
@@ -73,7 +73,7 @@ private fun Example2() {
 private fun Example3() {
     LottieAnimation(
         LottieCompositionSpec.RawRes(R.raw.heart),
-        repeatCount = Integer.MAX_VALUE,
+        repeatCount = LottieConstants.RepeatForever,
         clipSpec = LottieClipSpec.MinAndMaxProgress(0.5f, 0.75f),
     )
 }
@@ -118,7 +118,7 @@ private fun Example6() {
     val composition by lottieComposition(LottieCompositionSpec.RawRes(R.raw.heart))
     val progress by animateLottieComposition(
         composition,
-        repeatCount = Integer.MAX_VALUE,
+        repeatCount = LottieConstants.RepeatForever,
     )
     LottieAnimation(
         composition,
@@ -134,7 +134,7 @@ private fun Example7() {
     var isPlaying by remember { mutableStateOf(false) }
     LottieAnimation(
         LottieCompositionSpec.RawRes(R.raw.heart),
-        repeatCount = Integer.MAX_VALUE,
+        repeatCount = LottieConstants.RepeatForever,
         // When this is true, it it will start from 0 every time it is played again.
         // When this is false, it will resume from the progress it was pause at.
         restartOnPlay = false,

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/examples/DynamicPropertiesExamplesPage.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/examples/DynamicPropertiesExamplesPage.kt
@@ -1,0 +1,129 @@
+package com.airbnb.lottie.sample.compose.examples
+
+import android.graphics.PointF
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.airbnb.lottie.LottieProperty
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.rememberLottieDynamicProperties
+import com.airbnb.lottie.compose.rememberLottieDynamicProperty
+import com.airbnb.lottie.sample.compose.R
+
+@Composable
+fun DynamicPropertiesExamplesPage() {
+    UsageExamplePageScaffold {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+        ) {
+            ExampleCard("Heart Color", "Click to change color") {
+                HeartColor()
+            }
+            ExampleCard("Jump Height", "Click to jump heiht") {
+                JumpHeight()
+            }
+            ExampleCard("Change Properties", "Click to toggle whether the dynamic property is used") {
+                ToggleProperty()
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeartColor() {
+    val colors = remember {
+        listOf(
+            Color.Red,
+            Color.Green,
+            Color.Blue,
+            Color.Yellow,
+        )
+    }
+    var colorIndex by remember { mutableStateOf(0) }
+    val color by derivedStateOf { colors[colorIndex] }
+
+    val dynamicProperties = rememberLottieDynamicProperties(
+        rememberLottieDynamicProperty(LottieProperty.COLOR, color.toArgb(), "H2", "Shape 1", "Fill 1"),
+    )
+    LottieAnimation(
+        LottieCompositionSpec.RawRes(R.raw.heart),
+        repeatCount = Integer.MAX_VALUE,
+        dynamicProperties = dynamicProperties,
+        modifier = Modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = { colorIndex = (colorIndex + 1) % colors.size },
+            )
+    )
+}
+
+@Composable
+private fun JumpHeight() {
+    val extraJumpHeights = remember { listOf(0.dp, 24.dp, 48.dp, 128.dp) }
+    var extraJumpIndex by remember { mutableStateOf(0) }
+    val extraJumpHeight by derivedStateOf { extraJumpHeights[extraJumpIndex] }
+    val extraJumpHeightPx = with(LocalDensity.current) { extraJumpHeight.toPx() }
+
+    val point = remember { PointF() }
+    val dynamicProperties = rememberLottieDynamicProperties(
+        rememberLottieDynamicProperty(LottieProperty.TRANSFORM_POSITION, "Body") { frameInfo ->
+            var startY = frameInfo.startValue.y
+            var endY = frameInfo.endValue.y
+            when {
+                startY > endY -> startY += extraJumpHeightPx
+                else -> endY += extraJumpHeightPx
+            }
+            point.set(frameInfo.startValue.x, lerp(startY, endY, frameInfo.interpolatedKeyframeProgress))
+            point
+        }
+    )
+    LottieAnimation(
+        LottieCompositionSpec.Asset("AndroidWave.json"),
+        repeatCount = Integer.MAX_VALUE,
+        dynamicProperties = dynamicProperties,
+        modifier = Modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = { extraJumpIndex = (extraJumpIndex + 1) % extraJumpHeights.size },
+            )
+    )
+}
+
+@Composable
+private fun ToggleProperty() {
+    var useDynamicProperty by remember { mutableStateOf(true) }
+    val dynamicProperties = rememberLottieDynamicProperties(
+        rememberLottieDynamicProperty(LottieProperty.COLOR, Color.Green.toArgb(), "H2", "Shape 1", "Fill 1"),
+    )
+    LottieAnimation(
+        LottieCompositionSpec.RawRes(R.raw.heart),
+        repeatCount = Integer.MAX_VALUE,
+        dynamicProperties = dynamicProperties.takeIf { useDynamicProperty },
+        modifier = Modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = { useDynamicProperty = !useDynamicProperty },
+            )
+    )
+}
+
+private fun lerp(valueA: Float, valueB: Float, progress: Float): Float {
+    val smallerY = minOf(valueA, valueB)
+    val largerY = maxOf(valueA, valueB)
+    return smallerY + progress * (largerY - smallerY)
+}

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/examples/DynamicPropertiesExamplesPage.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/examples/DynamicPropertiesExamplesPage.kt
@@ -14,10 +14,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.airbnb.lottie.LottieProperty
-import com.airbnb.lottie.compose.LottieAnimation
-import com.airbnb.lottie.compose.LottieCompositionSpec
-import com.airbnb.lottie.compose.rememberLottieDynamicProperties
-import com.airbnb.lottie.compose.rememberLottieDynamicProperty
+import com.airbnb.lottie.compose.*
 import com.airbnb.lottie.sample.compose.R
 
 @Composable
@@ -59,7 +56,7 @@ private fun HeartColor() {
     )
     LottieAnimation(
         LottieCompositionSpec.RawRes(R.raw.heart),
-        repeatCount = Integer.MAX_VALUE,
+        repeatCount = LottieConstants.RepeatForever,
         dynamicProperties = dynamicProperties,
         modifier = Modifier
             .clickable(
@@ -92,7 +89,7 @@ private fun JumpHeight() {
     )
     LottieAnimation(
         LottieCompositionSpec.Asset("AndroidWave.json"),
-        repeatCount = Integer.MAX_VALUE,
+        repeatCount = LottieConstants.RepeatForever,
         dynamicProperties = dynamicProperties,
         modifier = Modifier
             .clickable(
@@ -111,7 +108,7 @@ private fun ToggleProperty() {
     )
     LottieAnimation(
         LottieCompositionSpec.RawRes(R.raw.heart),
-        repeatCount = Integer.MAX_VALUE,
+        repeatCount = LottieConstants.RepeatForever,
         dynamicProperties = dynamicProperties.takeIf { useDynamicProperty },
         modifier = Modifier
             .clickable(

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/examples/ExamplesPage.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/examples/ExamplesPage.kt
@@ -14,6 +14,7 @@ import com.airbnb.lottie.sample.compose.R
 import com.airbnb.lottie.sample.compose.Route
 import com.airbnb.lottie.sample.compose.composables.Marquee
 import com.airbnb.lottie.sample.compose.navigate
+import com.airbnb.lottie.sample.compose.utils.drawBottomBorder
 
 @Composable
 fun ExamplesPage(navController: NavController) {
@@ -22,23 +23,40 @@ fun ExamplesPage(navController: NavController) {
             .verticalScroll(rememberScrollState())
     ) {
         Marquee(stringResource(R.string.examples_title))
-        ListItem(
-            text = { Text("Basic Usage") },
-            secondaryText = { Text("Various example of simple Lottie usage.") },
-            modifier = Modifier
-                .clickable { navController.navigate(Route.BasicUsageExamples) }
+        ExampleListItem(
+            navController,
+            "Basic Usage",
+            "Various example of simple Lottie usage.",
+            Route.BasicUsageExamples,
         )
-        ListItem(
-            text = { Text("Transitions") },
-            secondaryText = { Text("Sequencing segments of an animation based on state.") },
-            modifier = Modifier
-                .clickable { navController.navigate(Route.TransitionsExamples) }
+        ExampleListItem(
+            navController,
+            "Transitions",
+            "Sequencing segments of an animation based on state.",
+            Route.TransitionsExamples,
         )
-        ListItem(
-            text = { Text("Network Animations") },
-            secondaryText = { Text("Loading animations from a url") },
-            modifier = Modifier
-                .clickable { navController.navigate(Route.NetworkExamples) }
+        ExampleListItem(
+            navController,
+            "Network Animations",
+            "Loading animations from a url",
+            Route.NetworkExamples,
+        )
+        ExampleListItem(
+            navController,
+            "Dynamic Properties",
+            "Dynamic Properties",
+            Route.DynamicPropertiesExamples,
         )
     }
+}
+
+@Composable
+private fun ExampleListItem(navController: NavController, title: String, description: String, route: Route) {
+    ListItem(
+        text = { Text(title) },
+        secondaryText = { Text(description) },
+        modifier = Modifier
+            .clickable { navController.navigate(route) }
+            .drawBottomBorder()
+    )
 }

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/player/PlayerPage.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/player/PlayerPage.kt
@@ -1,6 +1,5 @@
 package com.airbnb.lottie.sample.compose.player
 
-import android.util.Log
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
@@ -41,10 +40,7 @@ import com.airbnb.lottie.sample.compose.BuildConfig
 import com.airbnb.lottie.sample.compose.R
 import com.airbnb.lottie.sample.compose.composables.DebouncedCircularProgressIndicator
 import com.airbnb.lottie.sample.compose.ui.Teal
-import com.airbnb.lottie.sample.compose.utils.drawBottomBorder
-import com.airbnb.lottie.sample.compose.utils.maybeBackground
-import com.airbnb.lottie.sample.compose.utils.maybeDrawBorder
-import com.airbnb.lottie.sample.compose.utils.toDummyBitmap
+import com.airbnb.lottie.sample.compose.utils.*
 import kotlinx.coroutines.flow.collect
 import kotlin.math.ceil
 import kotlin.math.roundToInt
@@ -167,7 +163,7 @@ fun PlayerPageContent(
     var backgroundColor by remember(animationBackgroundColor) { mutableStateOf(animationBackgroundColor) }
     val dummyBitmapStrokeWidth = with(LocalDensity.current) { 3.dp.toPx() }
     val imageAssetDelegate = remember(compositionResult()) {
-        if (compositionResult()?.images?.any { (_, asset) -> asset.hasBitmap() } == true) {
+        if (compositionResult()?.hasEmbeddedBitmaps == true) {
             null
         } else {
             ImageAssetDelegate { if (it.hasBitmap()) null else it.toDummyBitmap(dummyBitmapStrokeWidth) }
@@ -272,9 +268,11 @@ private fun PlayerControlsRow(
                 state,
                 modifier = Modifier.weight(1f)
             )
-            IconButton(onClick = {
-                state.repeatCount = if (state.repeatCount == LottieConstants.RepeatForever) 1 else LottieConstants.RepeatForever
-            }) {
+            IconButton(
+                onClick = {
+                    state.repeatCount = if (state.repeatCount == LottieConstants.RepeatForever) 1 else LottieConstants.RepeatForever
+                },
+            ) {
                 Icon(
                     Icons.Filled.Repeat,
                     tint = if (state.repeatCount == LottieConstants.RepeatForever) Teal else Color.Black,

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/player/PlayerPage.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/player/PlayerPage.kt
@@ -52,7 +52,7 @@ import kotlin.math.roundToInt
 @Stable
 class PlayerPageState {
     var isPlaying by mutableStateOf(true)
-    var repeatCount by mutableStateOf(Integer.MAX_VALUE)
+    var repeatCount by mutableStateOf(LottieConstants.RepeatForever)
     var speed by mutableStateOf(1f)
     var outlineMasksAndMattes by mutableStateOf(false)
     var applyOpacityToLayers by mutableStateOf(false)
@@ -273,11 +273,11 @@ private fun PlayerControlsRow(
                 modifier = Modifier.weight(1f)
             )
             IconButton(onClick = {
-                state.repeatCount = if (state.repeatCount == Integer.MAX_VALUE) 1 else Integer.MAX_VALUE
+                state.repeatCount = if (state.repeatCount == LottieConstants.RepeatForever) 1 else LottieConstants.RepeatForever
             }) {
                 Icon(
                     Icons.Filled.Repeat,
-                    tint = if (state.repeatCount == Integer.MAX_VALUE) Teal else Color.Black,
+                    tint = if (state.repeatCount == LottieConstants.RepeatForever) Teal else Color.Black,
                     contentDescription = null
                 )
             }

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/utils/LottieExtensions.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/utils/LottieExtensions.kt
@@ -1,0 +1,5 @@
+package com.airbnb.lottie.sample.compose.utils
+
+import com.airbnb.lottie.LottieComposition
+
+val LottieComposition.hasEmbeddedBitmaps get() = images?.any { (_, asset) -> asset.hasBitmap() } == true


### PR DESCRIPTION
This PR builds on https://github.com/airbnb/lottie-android/pull/1793 and adds the ability to set dynamic properties. Example usage can be seen on `DynamicPropertiesExamplesPage.kt`.

Thanks to Compose's impressive snapshot system, states that are read during the drawing pass via the dynamic properties callback are automatically registered so invalidation happens correctly by default.