### PR TITLE
Downgrade espresso and AWS

### DIFF
--- a/sample-compose/build.gradle
+++ b/sample-compose/build.gradle
@@ -83,5 +83,5 @@ dependencies {
 
   testImplementation 'junit:junit:4.13.2'
   androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -92,9 +92,9 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1'
   implementation 'com.dlazaro66.qrcodereaderview:qrcodereaderview:2.0.2'
   implementation 'com.github.PhilJay:MPAndroidChart:3.1.0'
-  implementation 'com.amazonaws:aws-android-sdk-s3:2.28.0'
-  implementation ('com.amazonaws:aws-android-sdk-mobile-client:2.28.0@aar') { transitive = true }
-  implementation ('com.amazonaws:aws-android-sdk-auth-userpools:2.28.0@aar') { transitive = true }
+  implementation 'com.amazonaws:aws-android-sdk-s3:2.8.3'
+  implementation ('com.amazonaws:aws-android-sdk-mobile-client:2.8.3@aar') { transitive = true }
+  implementation ('com.amazonaws:aws-android-sdk-auth-userpools:2.8.3@aar') { transitive = true }
   implementation 'com.google.code.gson:gson:2.8.8'
   implementation 'com.squareup.okhttp3:okhttp:4.9.1'
   implementation 'com.squareup.retrofit2:retrofit:2.9.0'
@@ -108,8 +108,8 @@ dependencies {
 
   androidTestImplementation 'androidx.test:core:1.3.0'
   androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-  androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.4.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.3.0'
   androidTestImplementation 'androidx.test:rules:1.4.0'
   androidTestImplementation 'com.squareup.okhttp3:okhttp:4.9.1'
   androidTestImplementation 'io.jsonwebtoken:jjwt:0.9.1'


### PR DESCRIPTION
https://github.com/airbnb/lottie-android/pull/1874/ broke instrumentation tests:
1) Espresso broke with [this erro](https://github.com/airbnb/lottie-android/pull/1874/). It can probably be fixed by upgrading androidx test core but then there is a dependency conflict error which can probably be fixed by upgrading `androidx.fragment:fragment-testing` but there isn't a version of it that depends on test core 1.4.0.
2) The upgraded AWS SDK returns multiple status from the listener which caused the await continuation to be already resumed. I don't have time to debug the full behavior change and the old one was working fine.