### PR TITLE
[CI] Only run validate workflow on pushes to master

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,10 @@
 name: Validate
 
-on: [ push, pull_request ]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   gradle-wrapper:


### PR DESCRIPTION
Fixes https://github.com/airbnb/lottie-android/pull/1875. After this change, workflows were running twice on PRs.