### PR TITLE
[Compose] Parse LottieComposition synchronously instead of using LottieTask

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieCompositionSpec.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieCompositionSpec.kt
@@ -1,5 +1,7 @@
 package com.airbnb.lottie.compose
 
+import com.airbnb.lottie.LottieComposition
+
 /**
  * Specification for a [com.airbnb.lottie.LottieComposition]. Each subclass represents a different source.
  * A [com.airbnb.lottie.LottieComposition] is the stateless parsed version of a Lottie json file and is
@@ -41,4 +43,9 @@ sealed interface LottieCompositionSpec {
      * Load an animation from its json string.
      */
     inline class JsonString(val jsonString: String) : LottieCompositionSpec
+
+    /**
+     * Load an animation from a custom factory. This will be called on an IO thread pool.
+     */
+    inline class Custom(val factory: () -> LottieComposition) : LottieCompositionSpec
 }

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/rememberLottieComposition.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/rememberLottieComposition.kt
@@ -163,6 +163,13 @@ private fun parseCompositionSync(
             val jsonStringCacheKey = if (cacheKey == DefaultCacheKey) spec.jsonString.hashCode().toString() else cacheKey
             LottieCompositionFactory.fromJsonStringSync(spec.jsonString, jsonStringCacheKey)
         }
+        is LottieCompositionSpec.Custom -> {
+            try {
+                LottieResult(spec.factory())
+            } catch (e: Throwable) {
+                LottieResult<LottieComposition>(e)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Using LottieTask under the hood incurred several extra thread hops including a main thread post. Switching it to a result like this is both faster and also enables custom factories to be used. From my initial tests, this cut the parse time for the heart animation in the repo roughly in half.

Unfortunately, LaunchedTask takes a few ms to start. I tried with `rememberCoroutineScope().launch` and the initial delay was the same so I'm not sure if there is anything else that can be done here.

Fixes https://github.com/airbnb/lottie-android/issues/1880