### PR TITLE
Enforce order of operations to avoid rounding errors

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/BaseStrokeContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/BaseStrokeContent.java
@@ -226,9 +226,9 @@ public abstract class BaseStrokeContent
     }
     float offsetLength = totalLength * pathGroup.trimPath.getOffset().getValue() / 360f;
     float startLength =
-        totalLength * pathGroup.trimPath.getStart().getValue() / 100f + offsetLength;
+        totalLength * (pathGroup.trimPath.getStart().getValue() / 100f) + offsetLength;
     float endLength =
-        totalLength * pathGroup.trimPath.getEnd().getValue() / 100f + offsetLength;
+        totalLength * (pathGroup.trimPath.getEnd().getValue() / 100f) + offsetLength;
 
     float currentLength = 0;
     for (int j = pathGroup.paths.size() - 1; j >= 0; j--) {


### PR DESCRIPTION
Previously, the calculation of `endLength` could suffer from rounding errors. While most of the time, these errors are not a big deal, when the end value is 100, this can result in `endLength` being larger than `totalLength`, causing unexpected behavior where the animation reverts to an initial state when it should be showing the final state. By forcing the order of operations, we can get the answer we expect / need.

For example:

```kotlin
val totalLength = 98.164566
totalLength * 100f / 100f // 98.16457
totalLength * (100f / 100f) // 98.164566
```

Unfortunately, I have been unable to get a simple animation to reproduce this error, and the complex one I am using is not really available for public sharing. However, it seems like this should be a safe change.