### PR TITLE
Don't cache dpScale in Utils

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
@@ -66,7 +66,6 @@ public final class Utils {
   };
 
   private static final float INV_SQRT_2 = (float) (Math.sqrt(2) / 2.0);
-  private static float dpScale = -1;
 
   private Utils() {
   }
@@ -249,10 +248,7 @@ public final class Utils {
   }
 
   public static float dpScale() {
-    if (dpScale == -1) {
-      dpScale = Resources.getSystem().getDisplayMetrics().density;
-    }
-    return dpScale;
+    return Resources.getSystem().getDisplayMetrics().density;
   }
 
   public static float getAnimationScale(Context context) {


### PR DESCRIPTION
It's possible for the screen density to change when moving between windows or screens. In this case lottie renders animations the wrong size. Android already does a pretty good job of caching and updating the system context so just let it do it's job.

I am currently relying on reflection to clear this field on a configuration change and I'd of course like to remove that.

I haven't had time to come up with a generic repro, but I thought I'd open this anyway. Sorry.