### PR TITLE
Removed unnecessary int cast to avoid Integer allocations

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/ColorKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/ColorKeyframeAnimation.java
@@ -24,19 +24,17 @@ public class ColorKeyframeAnimation extends KeyframeAnimation<Integer> {
     if (keyframe.startValue == null || keyframe.endValue == null) {
       throw new IllegalStateException("Missing values for keyframe.");
     }
-    int startColor = keyframe.startValue;
-    int endColor = keyframe.endValue;
 
     if (valueCallback != null) {
       //noinspection ConstantConditions
-      Integer value = valueCallback.getValueInternal(keyframe.startFrame, keyframe.endFrame, startColor,
-          endColor, keyframeProgress, getLinearCurrentKeyframeProgress(), getProgress());
+      Integer value = valueCallback.getValueInternal(keyframe.startFrame, keyframe.endFrame, keyframe.startValue,
+          keyframe.endValue, keyframeProgress, getLinearCurrentKeyframeProgress(), getProgress());
       if (value != null) {
         return value;
       }
     }
 
-    return GammaEvaluator.evaluate(MiscUtils.clamp(keyframeProgress, 0f, 1f), startColor, endColor);
+    return GammaEvaluator.evaluate(MiscUtils.clamp(keyframeProgress, 0f, 1f), keyframe.startValue, keyframe.endValue);
   }
 
   /**


### PR DESCRIPTION
This pull request attempts to reduce Integer allocations when using an animation that has a ValueCallback to change some colors.

Resolves #1926 