### PR TITLE
Replaced Paint.setAlpha() with Paint.setColor() to reduce unnecessary allocations

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/LPaint.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/LPaint.java
@@ -1,8 +1,11 @@
 package com.airbnb.lottie.animation;
 
+import static com.airbnb.lottie.utils.MiscUtils.clamp;
+
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
+import android.os.Build;
 import android.os.LocaleList;
 
 import androidx.annotation.NonNull;
@@ -34,5 +37,14 @@ public class LPaint extends Paint {
   @Override
   public void setTextLocales(@NonNull LocaleList locales) {
     // Do nothing.
+  }
+
+  @Override public void setAlpha(int alpha) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      int color = getColor();
+      setColor((clamp(alpha, 0, 255) << 24) | (color & 0xFFFFFF));
+    } else {
+      super.setAlpha(clamp(alpha, 0, 255));
+    }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/animation/LPaint.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/LPaint.java
@@ -39,7 +39,15 @@ public class LPaint extends Paint {
     // Do nothing.
   }
 
-  @Override public void setAlpha(int alpha) {
+  /**
+   * Overrides {@link android.graphics.Paint#setAlpha(int)} to avoid
+   * unnecessary {@link android.graphics.ColorSpace.Named ColorSpace$Named[] }
+   * allocations when calling this method in Android 29 or lower.
+   *
+   * @param alpha set the alpha component [0..255] of the paint's color.
+   */
+  @Override
+  public void setAlpha(int alpha) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
       int color = getColor();
       setColor((clamp(alpha, 0, 255) << 24) | (color & 0xFFFFFF));

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/BaseStrokeContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/BaseStrokeContent.java
@@ -11,6 +11,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
 import android.graphics.RectF;
+import android.os.Build;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.Nullable;
@@ -161,7 +162,12 @@ public abstract class BaseStrokeContent
       return;
     }
     int alpha = (int) ((parentAlpha / 255f * ((IntegerKeyframeAnimation) opacityAnimation).getIntValue() / 100f) * 255);
-    paint.setAlpha(clamp(alpha, 0, 255));
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      int color = paint.getColor();
+      paint.setColor((clamp(alpha, 0, 255) << 24) | (color & 0xFFFFFF));
+    } else {
+      paint.setAlpha(clamp(alpha, 0, 255));
+    }
     paint.setStrokeWidth(((FloatKeyframeAnimation) widthAnimation).getFloatValue() * Utils.getScale(parentMatrix));
     if (paint.getStrokeWidth() <= 0) {
       // Android draws a hairline stroke for 0, After Effects doesn't.

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/BaseStrokeContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/BaseStrokeContent.java
@@ -11,7 +11,6 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
 import android.graphics.RectF;
-import android.os.Build;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.Nullable;
@@ -162,12 +161,7 @@ public abstract class BaseStrokeContent
       return;
     }
     int alpha = (int) ((parentAlpha / 255f * ((IntegerKeyframeAnimation) opacityAnimation).getIntValue() / 100f) * 255);
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-      int color = paint.getColor();
-      paint.setColor((clamp(alpha, 0, 255) << 24) | (color & 0xFFFFFF));
-    } else {
-      paint.setAlpha(clamp(alpha, 0, 255));
-    }
+    paint.setAlpha(clamp(alpha, 0, 255));
     paint.setStrokeWidth(((FloatKeyframeAnimation) widthAnimation).getFloatValue() * Utils.getScale(parentMatrix));
     if (paint.getStrokeWidth() <= 0) {
       // Android draws a hairline stroke for 0, After Effects doesn't.

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/FillContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/FillContent.java
@@ -98,9 +98,9 @@ public class FillContent
       return;
     }
     L.beginSection("FillContent#draw");
-    paint.setColor(((ColorKeyframeAnimation) colorAnimation).getIntValue());
+    int color = ((ColorKeyframeAnimation) this.colorAnimation).getIntValue();
     int alpha = (int) ((parentAlpha / 255f * opacityAnimation.getValue() / 100f) * 255);
-    paint.setAlpha(clamp(alpha, 0, 255));
+    paint.setColor((clamp(alpha, 0, 255) << 24) | (color & 0xFFFFFF));
 
     if (colorFilterAnimation != null) {
       paint.setColorFilter(colorFilterAnimation.getValue());


### PR DESCRIPTION
Resolves #1928 

This pull request attempts to remove ColorSpace.Named[] allocations when calling Paint.setAlpha(). These changes will fix the issue only when using RGB colors.