### PR TITLE
Fix a typo in the Compose LottieAnimation docs

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
@@ -33,7 +33,7 @@ import kotlin.math.roundToInt
  *                    [rememberLottieComposition].
  * @param progress The progress (between 0 and 1) that should be rendered. If you want to render a specific
  *                 frame, you can use [LottieComposition.getFrameForProgress]. In most cases, you will want
- *                 to use one of th overloaded LottieAnimation composables that drives the animation for you.
+ *                 to use one of the overloaded LottieAnimation composables that drives the animation for you.
  *                 The overloads that have isPlaying as a parameter instead of progress will drive the
  *                 animation automatically. You may want to use this version if you want to drive the animation
  *                 from your own Animatable or via events such as download progress or a gesture.


### PR DESCRIPTION
This PR contains a small typo fix in the documentation of the `LottieAnimation` composable.

Thank you for the great library and the Compose support! 🙏 