### PR TITLE
Add kotlin-android back to issue-repro

### DIFF
--- a/issue-repro/build.gradle
+++ b/issue-repro/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application'
+    id 'kotlin-android'
 }
 
 android {


### PR DESCRIPTION
Fixes an issue in which Kotlin code wasn't being compiled and the issue-repro module insta crashed unable to find IssueReproActivity