### PR TITLE
Replace LottieAnimationView layer types with internal bitmap rendering

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.2.2-SNAPSHOT
+VERSION_NAME=4.3.0-beta01-SNAPSHOT
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=Lottie is an animation library that renders Adobe After Effects animations natively in realtime.

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
@@ -1,6 +1,7 @@
 package com.airbnb.lottie.compose
 
 import android.graphics.Matrix
+import android.os.Build
 import androidx.annotation.FloatRange
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
@@ -21,6 +22,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.LottieDrawable
+import com.airbnb.lottie.RenderMode
 import com.airbnb.lottie.utils.Utils
 import kotlin.math.roundToInt
 
@@ -66,6 +68,7 @@ fun LottieAnimation(
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
     enableMergePaths: Boolean = false,
+    renderMode: RenderMode = RenderMode.AUTOMATIC,
     dynamicProperties: LottieDynamicProperties? = null,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
@@ -73,9 +76,11 @@ fun LottieAnimation(
     val drawable = remember { LottieDrawable() }
     val matrix = remember { Matrix() }
     var setDynamicProperties: LottieDynamicProperties? by remember { mutableStateOf(null) }
+    val useSoftwareRendering: Boolean = remember(renderMode, composition) {
+        renderMode.useSoftwareRendering(Build.VERSION.SDK_INT, composition?.hasDashPattern() ?: false, composition?.maskAndMatteCount ?: 0)
+    }
 
     if (composition == null || composition.duration == 0f) return Box(modifier)
-
 
     Canvas(
         modifier = modifier
@@ -101,6 +106,7 @@ fun LottieAnimation(
             drawable.setOutlineMasksAndMattes(outlineMasksAndMattes)
             drawable.isApplyingOpacityToLayersEnabled = applyOpacityToLayers
             drawable.enableMergePathsForKitKatAndAbove(enableMergePaths)
+            drawable.useSoftwareRendering(useSoftwareRendering)
             drawable.progress = progress
             drawable.draw(canvas.nativeCanvas, matrix)
         }
@@ -126,6 +132,7 @@ fun LottieAnimation(
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
     enableMergePaths: Boolean = false,
+    renderMode: RenderMode = RenderMode.AUTOMATIC,
     dynamicProperties: LottieDynamicProperties? = null,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
@@ -145,6 +152,7 @@ fun LottieAnimation(
         outlineMasksAndMattes,
         applyOpacityToLayers,
         enableMergePaths,
+        renderMode,
         dynamicProperties,
         alignment,
         contentScale,

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -1211,7 +1211,6 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       } else {
         softwareRenderingCanvas.drawRect(0f, 0f, intrinsicWidth, intrinsicHeight, softwareRenderingClearPaint);
       }
-      softwareRenderingBitmap.eraseColor(0);
       compositionLayer.draw(softwareRenderingCanvas, matrix, alpha);
       softwareRenderingBoundsRect.set(0, 0, intrinsicWidth, intrinsicHeight);
     }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -6,9 +6,13 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.Matrix;
+import android.graphics.Paint;
 import android.graphics.PixelFormat;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Animatable;
@@ -26,6 +30,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 
+import com.airbnb.lottie.animation.LPaint;
 import com.airbnb.lottie.manager.FontAssetManager;
 import com.airbnb.lottie.manager.ImageAssetManager;
 import com.airbnb.lottie.model.KeyPath;
@@ -100,7 +105,14 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   private boolean performanceTrackingEnabled;
   private boolean outlineMasksAndMattes;
   private boolean isApplyingOpacityToLayersEnabled;
-  private boolean isExtraScaleEnabled = true;
+
+  private boolean softwareRenderingEnabled = false;
+  private Bitmap softwareRenderingBitmap;
+  private final LPaint softwareRenderingClearPaint = new LPaint();
+  private final Canvas softwareRenderingCanvas = new Canvas();
+  private Paint softwareRenderingPaint;
+  private final Rect softwareRenderingBoundsRect = new Rect();
+
   /**
    * True if the drawable has not been drawn since the last invalidateSelf.
    * We can do this to prevent things like bounds from getting recalculated
@@ -246,6 +258,20 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     return true;
   }
 
+  /**
+   * When set to true, Lottie will first render your animation to a bitmap and then draw the bitmap
+   * onto the original canvas.
+   *
+   * @see LottieAnimationView#setRenderMode(RenderMode)
+   */
+  public void useSoftwareRendering(boolean softwareRenderingEnabled) {
+    if (this.softwareRenderingEnabled == softwareRenderingEnabled) {
+      return;
+    }
+    this.softwareRenderingEnabled = softwareRenderingEnabled;
+    invalidateSelf();
+  }
+
   public void setPerformanceTrackingEnabled(boolean enabled) {
     performanceTrackingEnabled = enabled;
     if (composition != null) {
@@ -295,18 +321,10 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   }
 
   /**
-   * Disable the extraScale mode in {@link #draw(Canvas)} function when scaleType is FitXY. It doesn't affect the rendering with other scaleTypes.
-   *
-   * <p>When there are 2 animation layout side by side, the default extra scale mode might leave 1 pixel not drawn between 2 animation, and
-   * disabling the extraScale mode can fix this problem</p>
-   *
-   * <b>Attention:</b> Disable the extra scale mode can downgrade the performance and may lead to larger memory footprint. Please only disable this
-   * mode when using animation with a reasonable dimension (smaller than screen size).
-   *
-   * @see #drawWithNewAspectRatio(Canvas)
+   * This API no longer has any effect.
    */
+  @Deprecated
   public void disableExtraScaleModeInFitXY() {
-    this.isExtraScaleEnabled = false;
   }
 
   public boolean isApplyingOpacityToLayersEnabled() {
@@ -379,8 +397,6 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
 
   @Override
   public void draw(@NonNull Canvas canvas) {
-    isDirty = false;
-
     L.beginSection("Drawable#draw");
 
     if (safeMode) {
@@ -392,6 +408,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     } else {
       drawInternal(canvas);
     }
+    isDirty = false;
 
     L.endSection("Drawable#draw");
   }
@@ -446,12 +463,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   @MainThread
   public void playAnimation() {
     if (compositionLayer == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          playAnimation();
-        }
-      });
+      lazyCompositionTasks.add(c -> playAnimation());
       return;
     }
 
@@ -477,12 +489,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   @MainThread
   public void resumeAnimation() {
     if (compositionLayer == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          resumeAnimation();
-        }
-      });
+      lazyCompositionTasks.add(c -> resumeAnimation());
       return;
     }
 
@@ -500,12 +507,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMinFrame(final int minFrame) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMinFrame(minFrame);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMinFrame(minFrame));
       return;
     }
     animator.setMinFrame(minFrame);
@@ -523,12 +525,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMinProgress(final float minProgress) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMinProgress(minProgress);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMinProgress(minProgress));
       return;
     }
     setMinFrame((int) MiscUtils.lerp(composition.getStartFrame(), composition.getEndFrame(), minProgress));
@@ -542,12 +539,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMaxFrame(final int maxFrame) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMaxFrame(maxFrame);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMaxFrame(maxFrame));
       return;
     }
     animator.setMaxFrame(maxFrame + 0.99f);
@@ -565,12 +557,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMaxProgress(@FloatRange(from = 0f, to = 1f) final float maxProgress) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMaxProgress(maxProgress);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMaxProgress(maxProgress));
       return;
     }
     setMaxFrame((int) MiscUtils.lerp(composition.getStartFrame(), composition.getEndFrame(), maxProgress));
@@ -583,12 +570,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMinFrame(final String markerName) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMinFrame(markerName);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMinFrame(markerName));
       return;
     }
     Marker marker = composition.getMarker(markerName);
@@ -605,12 +587,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMaxFrame(final String markerName) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMaxFrame(markerName);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMaxFrame(markerName));
       return;
     }
     Marker marker = composition.getMarker(markerName);
@@ -628,12 +605,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMinAndMaxFrame(final String markerName) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMinAndMaxFrame(markerName);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMinAndMaxFrame(markerName));
       return;
     }
     Marker marker = composition.getMarker(markerName);
@@ -654,12 +626,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMinAndMaxFrame(final String startMarkerName, final String endMarkerName, final boolean playEndMarkerStartFrame) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMinAndMaxFrame(startMarkerName, endMarkerName, playEndMarkerStartFrame);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMinAndMaxFrame(startMarkerName, endMarkerName, playEndMarkerStartFrame));
       return;
     }
     Marker startMarker = composition.getMarker(startMarkerName);
@@ -683,12 +650,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setMinAndMaxFrame(final int minFrame, final int maxFrame) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMinAndMaxFrame(minFrame, maxFrame);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMinAndMaxFrame(minFrame, maxFrame));
       return;
     }
     // Adding 0.99 ensures that the maxFrame itself gets played.
@@ -703,12 +665,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       @FloatRange(from = 0f, to = 1f) final float minProgress,
       @FloatRange(from = 0f, to = 1f) final float maxProgress) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setMinAndMaxProgress(minProgress, maxProgress);
-        }
-      });
+      lazyCompositionTasks.add(c -> setMinAndMaxProgress(minProgress, maxProgress));
       return;
     }
 
@@ -783,12 +740,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    */
   public void setFrame(final int frame) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setFrame(frame);
-        }
-      });
+      lazyCompositionTasks.add(c -> setFrame(frame));
       return;
     }
 
@@ -804,12 +756,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
 
   public void setProgress(@FloatRange(from = 0f, to = 1f) final float progress) {
     if (composition == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          setProgress(progress);
-        }
-      });
+      lazyCompositionTasks.add(c -> setProgress(progress));
       return;
     }
     L.beginSection("Drawable#setProgress");
@@ -1023,12 +970,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   public <T> void addValueCallback(
       final KeyPath keyPath, final T property, @Nullable final LottieValueCallback<T> callback) {
     if (compositionLayer == null) {
-      lazyCompositionTasks.add(new LazyCompositionTask() {
-        @Override
-        public void run(LottieComposition composition) {
-          addValueCallback(keyPath, property, callback);
-        }
-      });
+      lazyCompositionTasks.add(c -> addValueCallback(keyPath, property, callback));
       return;
     }
     boolean invalidate;
@@ -1190,16 +1132,6 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     callback.unscheduleDrawable(this, what);
   }
 
-  /**
-   * If the composition is larger than the canvas, we have to use a different method to scale it up.
-   * See the comments in {@link #draw(Canvas)} for more info.
-   */
-  private float getMaxScale(@NonNull Canvas canvas, LottieComposition composition) {
-    float maxScaleX = canvas.getWidth() / (float) composition.getBounds().width();
-    float maxScaleY = canvas.getHeight() / (float) composition.getBounds().height();
-    return Math.min(maxScaleX, maxScaleY);
-  }
-
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public void draw(Canvas canvas, Matrix matrix) {
     CompositionLayer compositionLayer = this.compositionLayer;
@@ -1216,41 +1148,17 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       return;
     }
 
-    int saveCount = -1;
     Rect bounds = getBounds();
     // In fitXY mode, the scale doesn't take effect.
     float scaleX = bounds.width() / (float) composition.getBounds().width();
     float scaleY = bounds.height() / (float) composition.getBounds().height();
 
-    if (isExtraScaleEnabled) {
-      float maxScale = Math.min(scaleX, scaleY);
-      float extraScale = 1f;
-      if (maxScale < 1f) {
-        extraScale = extraScale / maxScale;
-        scaleX = scaleX / extraScale;
-        scaleY = scaleY / extraScale;
-      }
-
-      if (extraScale > 1) {
-        saveCount = canvas.save();
-        float halfWidth = bounds.width() / 2f;
-        float halfHeight = bounds.height() / 2f;
-        float scaledHalfWidth = halfWidth * maxScale;
-        float scaledHalfHeight = halfHeight * maxScale;
-
-        canvas.translate(
-            halfWidth - scaledHalfWidth,
-            halfHeight - scaledHalfHeight);
-        canvas.scale(extraScale, extraScale, scaledHalfWidth, scaledHalfHeight);
-      }
-    }
-
     matrix.reset();
     matrix.preScale(scaleX, scaleY);
-    compositionLayer.draw(canvas, matrix, alpha);
-
-    if (saveCount > 0) {
-      canvas.restoreToCount(saveCount);
+    if (softwareRenderingEnabled) {
+      renderAndDrawAsBitmap(canvas, compositionLayer, matrix);
+    } else {
+      compositionLayer.draw(canvas, matrix, alpha);
     }
   }
 
@@ -1262,42 +1170,51 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     }
 
     float scale = this.scale;
-    float extraScale = 1f;
-    float maxScale = getMaxScale(canvas, composition);
-    if (scale > maxScale) {
-      scale = maxScale;
-      extraScale = this.scale / scale;
-    }
-
-    int saveCount = -1;
-    if (extraScale > 1) {
-      // This is a bit tricky...
-      // We can't draw on a canvas larger than ViewConfiguration.get(context).getScaledMaximumDrawingCacheSize()
-      // which works out to be roughly the size of the screen because Android can't generate a
-      // bitmap large enough to render to.
-      // As a result, we cap the scale such that it will never be wider/taller than the screen
-      // and then only render in the top left corner of the canvas. We then use extraScale
-      // to scale up the rest of the scale. However, since we rendered the animation to the top
-      // left corner, we need to scale up and translate the canvas to zoom in on the top left
-      // corner.
-      saveCount = canvas.save();
-      float halfWidth = composition.getBounds().width() / 2f;
-      float halfHeight = composition.getBounds().height() / 2f;
-      float scaledHalfWidth = halfWidth * scale;
-      float scaledHalfHeight = halfHeight * scale;
-
-      canvas.translate(
-          getScale() * halfWidth - scaledHalfWidth,
-          getScale() * halfHeight - scaledHalfHeight);
-      canvas.scale(extraScale, extraScale, scaledHalfWidth, scaledHalfHeight);
-    }
 
     matrix.reset();
     matrix.preScale(scale, scale);
-    compositionLayer.draw(canvas, matrix, alpha);
-
-    if (saveCount > 0) {
-      canvas.restoreToCount(saveCount);
+    if (softwareRenderingEnabled) {
+      renderAndDrawAsBitmap(canvas, compositionLayer, matrix);
+    } else {
+      compositionLayer.draw(canvas, matrix, alpha);
     }
+  }
+
+  /**
+   * This is the software rendering pipeline. This draws the animation to an internally managed bitmap
+   * and then draws the bitmap to the original canvas.
+   *
+   * @see LottieDrawable#useSoftwareRendering(boolean)
+   * @see LottieAnimationView#setRenderMode(RenderMode)
+   */
+  private void renderAndDrawAsBitmap(Canvas originalCanvas, CompositionLayer compositionLayer, Matrix matrix) {
+    if (softwareRenderingPaint == null) {
+      softwareRenderingPaint = new LPaint();
+    }
+
+    int intrinsicWidth = getIntrinsicWidth();
+    int intrinsicHeight = getIntrinsicHeight();
+
+    if (softwareRenderingBitmap == null ||
+        softwareRenderingBitmap.getWidth() < intrinsicWidth ||
+        softwareRenderingBitmap.getHeight() < intrinsicHeight) {
+      softwareRenderingBitmap = Bitmap.createBitmap(intrinsicWidth, intrinsicHeight, Bitmap.Config.ARGB_8888);
+      softwareRenderingCanvas.setBitmap(softwareRenderingBitmap);
+      softwareRenderingClearPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
+      softwareRenderingClearPaint.setColor(Color.BLACK);
+    }
+
+    if (isDirty) {
+      if (softwareRenderingBitmap.getWidth() == intrinsicWidth && softwareRenderingBitmap.getHeight() == intrinsicHeight) {
+        // eraseColor is ~10% faster than drawRect when covering the entire bitmap.
+        softwareRenderingBitmap.eraseColor(0);
+      } else {
+        softwareRenderingCanvas.drawRect(0f, 0f, intrinsicWidth, intrinsicHeight, softwareRenderingClearPaint);
+      }
+      softwareRenderingBitmap.eraseColor(0);
+      compositionLayer.draw(softwareRenderingCanvas, matrix, alpha);
+      softwareRenderingBoundsRect.set(0, 0, intrinsicWidth, intrinsicHeight);
+    }
+    originalCanvas.drawBitmap(softwareRenderingBitmap, softwareRenderingBoundsRect, softwareRenderingBoundsRect, softwareRenderingPaint);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/RenderMode.java
+++ b/lottie/src/main/java/com/airbnb/lottie/RenderMode.java
@@ -1,5 +1,7 @@
 package com.airbnb.lottie;
 
+import android.os.Build;
+
 /**
  * Controls how Lottie should render.
  * Defaults to {@link RenderMode#AUTOMATIC}.
@@ -9,5 +11,31 @@ package com.airbnb.lottie;
 public enum RenderMode {
   AUTOMATIC,
   HARDWARE,
-  SOFTWARE
+  SOFTWARE;
+
+  public boolean useSoftwareRendering(int sdkInt, boolean hasDashPattern, int numMasksAndMattes) {
+    switch (this) {
+      case HARDWARE:
+        return false;
+      case SOFTWARE:
+        return true;
+      case AUTOMATIC:
+      default:
+        if (hasDashPattern && sdkInt < Build.VERSION_CODES.P) {
+          // Hardware acceleration didn't support dash patterns until Pie.
+          return true;
+        } else if (numMasksAndMattes > 4) {
+          // This was chosen somewhat arbitrarily by trying a handful of animations.
+          // Animations with zero or few masks or mattes tend to perform much better with hardware
+          // acceleration. However, if there are many masks or mattes, it *may* perform worse.
+          // If you are hitting this case with AUTOMATIC set, please manually verify which one
+          // performs better.
+          return true;
+        }
+        // There have been many reported crashes from many device that are running Nougat or below.
+        // These devices also support far fewer hardware accelerated canvas operations.
+        // https://developer.android.com/guide/topics/graphics/hardware-accel#unsupported
+        return sdkInt <= Build.VERSION_CODES.N_MR1;
+    }
+  }
 }

--- a/sample/src/main/kotlin/com/airbnb/lottie/samples/PlayerFragment.kt
+++ b/sample/src/main/kotlin/com/airbnb/lottie/samples/PlayerFragment.kt
@@ -152,13 +152,13 @@ class PlayerFragment : BaseMvRxFragment(R.layout.player_fragment) {
         }
 
         binding.controlBar.hardwareAccelerationToggle.setOnClickListener {
-            val renderMode = if (binding.animationView.layerType == View.LAYER_TYPE_HARDWARE) {
+            val renderMode = if (binding.animationView.renderMode == RenderMode.HARDWARE) {
                 RenderMode.SOFTWARE
             } else {
                 RenderMode.HARDWARE
             }
-            binding.animationView.setRenderMode(renderMode)
-            binding.controlBar.hardwareAccelerationToggle.isActivated = binding.animationView.layerType == View.LAYER_TYPE_HARDWARE
+            binding.animationView.renderMode = renderMode
+            binding.controlBar.hardwareAccelerationToggle.isActivated = binding.animationView.renderMode == RenderMode.HARDWARE
         }
 
         binding.controlBar.enableApplyingOpacityToLayers.setOnClickListener {
@@ -435,7 +435,7 @@ class PlayerFragment : BaseMvRxFragment(R.layout.player_fragment) {
         }
 
         binding.animationView.setComposition(composition)
-        binding.controlBar.hardwareAccelerationToggle.isActivated = binding.animationView.layerType == View.LAYER_TYPE_HARDWARE
+        binding.controlBar.hardwareAccelerationToggle.isActivated = binding.animationView.renderMode == RenderMode.HARDWARE
         binding.animationView.setPerformanceTrackingEnabled(true)
         var renderTimeGraphRange = 4f
         binding.animationView.performanceTracker?.addFrameListener { ms ->
@@ -447,7 +447,7 @@ class PlayerFragment : BaseMvRxFragment(R.layout.player_fragment) {
         }
 
         // Scale up to fill the screen
-        binding.controlBarScale.scaleSeekBar.progress = 100
+        binding.controlBarScale.scaleSeekBar.progress = 50
 
         binding.bottomSheetKeyPaths.keyPathsRecyclerView.buildModelsWith(object : EpoxyRecyclerView.ModelBuilderCallback {
             override fun buildModels(controller: EpoxyController) {
@@ -512,7 +512,7 @@ class PlayerFragment : BaseMvRxFragment(R.layout.player_fragment) {
         return@withState min(
                 screenWidth / (bounds?.width()?.toFloat() ?: screenWidth),
                 screenHeight / (bounds?.height()?.toFloat() ?: screenHeight)
-        )
+        ) * 2f
     }
 
     private fun beginDelayedTransition() = TransitionManager.beginDelayedTransition(binding.container, transition)

--- a/sample/src/main/res/layout/player_fragment.xml
+++ b/sample/src/main/res/layout/player_fragment.xml
@@ -20,8 +20,9 @@
 
             <com.airbnb.lottie.LottieAnimationView
                 android:id="@+id/animationView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="center"
                 android:layout_gravity="center"
                 android:background="@drawable/outline"
                 app:lottie_autoPlay="true" />

--- a/snapshot-tests/src/main/AndroidManifest.xml
+++ b/snapshot-tests/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:largeHeap="true"
         android:roundIcon="@mipmap/ic_launcher"
         android:theme="@style/Theme.LottieCompose">
 


### PR DESCRIPTION
This change marks a significant change in the underlying rendering pipeline for Lottie.

Previously, Lottie would always set a layerType on LottieAnimationView. For hardware accelerated animations, this meant that a separate graphics layer was allocated for the animation. The disadvantage with this method is that the texture has to be uploaded separately to the GPU on each frame.

For software rendering, Lottie would depend on Android's view caching mechanism in which View allocates a drawing cache bitmap which it then draws to a canvas. This has the disadvantage of the Bitmap always being the size of the containing View even if it's larger than the drawable.
It also abstracts away the Bitmap so that further optimizations. When software rendering is enabled and it has to be redrawn without getting invalidated then it can skip re-rendering and simply redraw the cached bitmap.
It also upstream the bitmap rendering form LottieAnimationView to LottieDrawable which allows it to be exposed to lottie-compose which is important for the same reasons it is important for the base library and wasn't possible before.

While working on this PR, I tried rendering and then drawing only the bounds of the animation. However, I found that calculating the bounds for the entire animation was slower than drawing the entire bitmap (which is very fast).

Fixes https://github.com/airbnb/lottie-android/issues/1387