### PR TITLE
Fix a potential NPE race conditions

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -314,6 +314,10 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   }
 
   private void buildCompositionLayer() {
+    LottieComposition composition = this.composition;
+    if (composition == null) {
+      return;
+    }
     compositionLayer = new CompositionLayer(
         this, LayerParser.parse(composition), composition.getLayers(), composition);
     if (outlineMasksAndMattes) {


### PR DESCRIPTION
This PR addresses the issue #1958 , although the crash is pretty hard to reproducible, the enhancement will definitely make it more robust.

The issue was in `com.airbnb.lottie.LottieDrawable#buildCompositionLayer` method.
The related code is:
```
  private void buildCompositionLayer() {
    compositionLayer = new CompositionLayer(
        this, LayerParser.parse(composition), composition.getLayers(), composition);
    if (outlineMasksAndMattes) {
      compositionLayer.setOutlineMasksAndMattes(true);
    }
  }
```

The crash exception stack prints:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.List com.airbnb.lottie.LottieComposition.getLayers()' on a null object reference
       at com.airbnb.lottie.LottieDrawable.buildCompositionLayer(LottieDrawable.java:298)
       ...
```

As we can see, the exception occurs at composition.getLayers(), but before executing this statement, the LayerParser.parse(composition) statement also refers to the composition object, which was fine, but after that this object had been set to null, thus caused NPE.

I think this issue is very similar to the issues resolved in PR #1917 