### PR TITLE
[Compose] Add LottieCompositionSpec.ContentProvider

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieCompositionSpec.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieCompositionSpec.kt
@@ -1,5 +1,7 @@
 package com.airbnb.lottie.compose
 
+import android.net.Uri
+
 /**
  * Specification for a [com.airbnb.lottie.LottieComposition]. Each subclass represents a different source.
  * A [com.airbnb.lottie.LottieComposition] is the stateless parsed version of a Lottie json file and is
@@ -10,7 +12,8 @@ sealed interface LottieCompositionSpec {
     /**
      * Load an animation from res/raw.
      */
-    inline class RawRes(@androidx.annotation.RawRes val resId: Int) : LottieCompositionSpec
+    @JvmInline
+    value class RawRes(@androidx.annotation.RawRes val resId: Int) : LottieCompositionSpec
 
     /**
      * Load an animation from the internet. Lottie has a default network stack that will use
@@ -23,22 +26,32 @@ sealed interface LottieCompositionSpec {
      * passing this spec directly into [LottieAnimation] because it can fail and you want to
      * make sure that you properly handle the failures and/or retries.
      */
-    inline class Url(val url: String) : LottieCompositionSpec
+    @JvmInline
+    value class Url(val url: String) : LottieCompositionSpec
 
     /**
      * Load an animation from an arbitrary file. Make sure that your app has permissions to read it
      * or else this may fail.
      */
-    inline class File(val fileName: String) : LottieCompositionSpec
+    @JvmInline
+    value class File(val fileName: String) : LottieCompositionSpec
 
     /**
      * Load an animation from the assets directory of your app. This isn't type safe like [RawRes]
      * so make sure that the path to your animation is correct this will fail.
      */
-    inline class Asset(val assetName: String) : LottieCompositionSpec
+    @JvmInline
+    value class Asset(val assetName: String) : LottieCompositionSpec
 
     /**
      * Load an animation from its json string.
      */
-    inline class JsonString(val jsonString: String) : LottieCompositionSpec
+    @JvmInline
+    value class JsonString(val jsonString: String) : LottieCompositionSpec
+
+    /**
+     * Load an animation from a content provider URI.
+     */
+    @JvmInline
+    value class ContentProvider(val uri: Uri) : LottieCompositionSpec
 }

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/rememberLottieComposition.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/rememberLottieComposition.kt
@@ -181,11 +181,7 @@ private fun lottieTask(
         }
         is LottieCompositionSpec.ContentProvider -> {
             val inputStream = context.contentResolver.openInputStream(spec.uri)
-            if (cacheKey == DefaultCacheKey) {
-                LottieCompositionFactory.fromJsonInputStream(inputStream, spec.uri.toString())
-            } else {
-                LottieCompositionFactory.fromJsonInputStream(inputStream, cacheKey)
-            }
+            LottieCompositionFactory.fromJsonInputStream(inputStream, if (cacheKey == DefaultCacheKey) spec.uri.toString() else cacheKey)
         }
     }
 }


### PR DESCRIPTION
This adds a new `LottieCompositionSpec` option to load an animation from a content provider URI. This wasn't needed pre-Compose because you could get the input stream and parse the animation using that. However, Lottie Compose doesn't provide a direct API to parse an animation from an input stream. It doesn't expose that because a closeable input stream isn't a great candidate to put in a data class and makes `LottieCompositionSpec` stateful and closeable.

I also noticed some inconsistency in the way cache keys were handled for other specs so I fixed those as well.

Fixes #1978 