### PR TITLE
[Compose] Prevent infinite Lottie animations from preventing tests from going idle

### DIFF
--- a/sample-compose/build.gradle
+++ b/sample-compose/build.gradle
@@ -12,6 +12,7 @@ android {
     targetSdk 30
     versionCode 1
     versionName VERSION_NAME
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   buildTypes {
     release {
@@ -39,6 +40,10 @@ android {
   }
   composeOptions {
     kotlinCompilerExtensionVersion composeVersion
+  }
+  packagingOptions {
+    exclude 'META-INF/AL2.0'
+    exclude 'META-INF/LGPL2.1'
   }
 }
 
@@ -72,4 +77,8 @@ dependencies {
   implementation "com.google.accompanist:accompanist-pager-indicators:0.18.0"
   implementation 'com.airbnb.android:mavericks:2.3.0'
   implementation 'com.airbnb.android:mavericks-compose:2.1.0-alpha02'
+
+  debugImplementation "androidx.compose.ui:ui-test-manifest:$composeVersion"
+
+  androidTestImplementation "androidx.compose.ui:ui-test-junit4:$composeVersion"
 }

--- a/sample-compose/src/androidTest/java/com/airbnb/lottie/samples/InfiniteAnimationTest.kt
+++ b/sample-compose/src/androidTest/java/com/airbnb/lottie/samples/InfiniteAnimationTest.kt
@@ -1,0 +1,57 @@
+package com.airbnb.lottie.samples
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import com.airbnb.lottie.LottieCompositionFactory
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieConstants
+import com.airbnb.lottie.compose.animateLottieCompositionAsState
+import com.airbnb.lottie.sample.compose.ComposeActivity
+import com.airbnb.lottie.sample.compose.R
+import org.junit.Rule
+import org.junit.Test
+
+class InfiniteAnimationTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule(ComposeActivity::class.java)
+
+    @Test
+    fun testInfiniteAnimation() {
+        val composition = LottieCompositionFactory.fromRawResSync(composeTestRule.activity, R.raw.heart).value!!
+        composeTestRule.setContent {
+            val progress by animateLottieCompositionAsState(composition, iterations = LottieConstants.IterateForever)
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                LottieAnimation(
+                    composition,
+                    progress,
+                )
+                Text(
+                    "Composition Loaded!",
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(
+                            top = 16.dp
+                        )
+                )
+            }
+        }
+
+
+        composeTestRule
+            .onNodeWithText("Composition Loaded!")
+            .assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
You can see how androidx handles this in AndroidTestComposeRule [here](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-test-junit4/src/androidMain/kotlin/androidx/compose/ui/test/junit4/AndroidComposeTestRule.android.kt;l=187?q=InfiniteAnimationPolicy%20lang:kotlin).

Fixes https://github.com/airbnb/lottie-android/issues/1907