### PR TITLE
[Compose] Set merge paths before the composition

### DIFF
--- a/CHANGELOG_COMPOSE.md
+++ b/CHANGELOG_COMPOSE.md
@@ -3,6 +3,7 @@
 * Added support for loading animations via content provider URIs (LottieCompositionSpec.ContentProvider) ([#1982](https://github.com/airbnb/lottie-android/pull/1982))
 * Fixed dynamic gradient properties ([#1969](https://github.com/airbnb/lottie-android/pull/1969)).
 * Prevent infinite animations from hanging espresso tests by using the same mechanism as androidx animations ([#1987](https://github.com/airbnb/lottie-android/pull/1987))
+* Set the merge paths property before the composition to avoid building the composition layer with the wrong merge paths value and triggering a second rebuilt ([#1997](https://github.com/airbnb/lottie-android/pull/1997))
 
 # 4.2.0
 * [BREAKING CHANGE] LottieAnimation will now default to the composition size rather than `fillMaxSize()` ([#1892](https://github.com/airbnb/lottie-android/pull/1892))

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
@@ -105,6 +105,7 @@ fun LottieAnimation(
             matrix.preTranslate(translation.x.toFloat(), translation.y.toFloat())
             matrix.preScale(scale.scaleX, scale.scaleY)
 
+            drawable.enableMergePathsForKitKatAndAbove(enableMergePaths)
             drawable.composition = composition
             if (dynamicProperties !== setDynamicProperties) {
                 setDynamicProperties?.removeFrom(drawable)
@@ -113,7 +114,6 @@ fun LottieAnimation(
             }
             drawable.setOutlineMasksAndMattes(outlineMasksAndMattes)
             drawable.isApplyingOpacityToLayersEnabled = applyOpacityToLayers
-            drawable.enableMergePathsForKitKatAndAbove(enableMergePaths)
             drawable.useSoftwareRendering(useSoftwareRendering)
             drawable.maintainOriginalImageBounds = maintainOriginalImageBounds
             drawable.clipToCompositionBounds = clipToComposition


### PR DESCRIPTION
The correct value for merge paths must be set before setting the composition.

Fixes https://github.com/airbnb/lottie-android/issues/1970