### PR TITLE
[Compose] Respect system animator scale

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimatable.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimatable.kt
@@ -213,7 +213,6 @@ private class LottieAnimatableImpl : LottieAnimatable {
         ignoreSystemAnimationsDisabled: Boolean,
     ) {
         mutex.mutate {
-            require(speed.isFinite()) { "Speed must be a finite number. It is $speed." }
             this.iteration = iteration
             this.iterations = iterations
             this.speed = speed
@@ -223,6 +222,11 @@ private class LottieAnimatableImpl : LottieAnimatable {
             if (!continueFromPreviousAnimate) lastFrameNanos = AnimationConstants.UnspecifiedTime
             if (composition == null) {
                 isPlaying = false
+                return@mutate
+            } else if (speed.isInfinite()) {
+                progress = endProgress
+                isPlaying = false
+                this.iteration = iterations
                 return@mutate
             }
 

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimatable.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimatable.kt
@@ -126,6 +126,8 @@ interface LottieAnimatable : LottieAnimationState {
      *                             you will want it to cancel immediately. However, if you have a state based
      *                             transition and you want an animation to finish playing before moving on to
      *                             the next one then you may want to set this to [LottieCancellationBehavior.OnIterationFinish].
+     * @param ignoreSystemAnimationsDisabled When set to true, the animation will animate even if animations are disabled at the OS level.
+     *                                       Defaults to false.
      */
     suspend fun animate(
         composition: LottieComposition?,
@@ -133,9 +135,10 @@ interface LottieAnimatable : LottieAnimationState {
         iterations: Int = this.iterations,
         speed: Float = this.speed,
         clipSpec: LottieClipSpec? = this.clipSpec,
-        initialProgress: Float =  defaultProgress(composition, clipSpec, speed),
+        initialProgress: Float = defaultProgress(composition, clipSpec, speed),
         continueFromPreviousAnimate: Boolean = false,
         cancellationBehavior: LottieCancellationBehavior = LottieCancellationBehavior.Immediately,
+        ignoreSystemAnimationsDisabled: Boolean = false,
     )
 }
 
@@ -207,6 +210,7 @@ private class LottieAnimatableImpl : LottieAnimatable {
         initialProgress: Float,
         continueFromPreviousAnimate: Boolean,
         cancellationBehavior: LottieCancellationBehavior,
+        ignoreSystemAnimationsDisabled: Boolean,
     ) {
         mutex.mutate {
             require(speed.isFinite()) { "Speed must be a finite number. It is $speed." }

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieConstants.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieConstants.kt
@@ -7,10 +7,4 @@ object LottieConstants {
      * Use this with [animateLottieCompositionAsState]'s iterations parameter to repeat forever.
      */
     const val IterateForever = Integer.MAX_VALUE
-
-    internal var SystemAnimationsDisabled = false
-
-    internal fun updateSystemAnimationsDisabled(context: Context) {
-        
-    }
 }

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieConstants.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieConstants.kt
@@ -1,8 +1,16 @@
 package com.airbnb.lottie.compose
 
+import android.content.Context
+
 object LottieConstants {
     /**
      * Use this with [animateLottieCompositionAsState]'s iterations parameter to repeat forever.
      */
     const val IterateForever = Integer.MAX_VALUE
+
+    internal var SystemAnimationsDisabled = false
+
+    internal fun updateSystemAnimationsDisabled(context: Context) {
+        
+    }
 }

--- a/lottie-compose/src/test/java/com/airbnb/lottie/compose/LottieAnimatableImplTest.kt
+++ b/lottie-compose/src/test/java/com/airbnb/lottie/compose/LottieAnimatableImplTest.kt
@@ -279,6 +279,70 @@ class LottieAnimatableImplTest {
     }
 
     @Test
+    fun testInfiniteSpeed() {
+        val clipSpec = LottieClipSpec.Progress(0.33f, 0.57f)
+        runTest {
+            launch {
+                anim.animate(composition, clipSpec = clipSpec, speed = Float.POSITIVE_INFINITY, iterations = LottieConstants.IterateForever)
+            }
+            assertFrame(
+                0,
+                progress = 0.57f,
+                isPlaying = false,
+                speed = Float.POSITIVE_INFINITY,
+                clipSpec = clipSpec,
+                isAtEnd = true,
+                iterations = LottieConstants.IterateForever,
+                iteration = LottieConstants.IterateForever,
+                lastFrameNanos = AnimationConstants.UnspecifiedTime,
+            )
+        }
+    }
+
+    @Test
+    fun testInfiniteSpeedWithIterations() {
+        val clipSpec = LottieClipSpec.Progress(0.33f, 0.57f)
+        runTest {
+            launch {
+                anim.animate(composition, clipSpec = clipSpec, speed = Float.POSITIVE_INFINITY, iterations = 3)
+            }
+            assertFrame(
+                300,
+                progress = 0.57f,
+                isPlaying = false,
+                speed = Float.POSITIVE_INFINITY,
+                clipSpec = clipSpec,
+                isAtEnd = true,
+                iterations = 3,
+                iteration = 3,
+                lastFrameNanos = AnimationConstants.UnspecifiedTime,
+            )
+        }
+    }
+
+    @Test
+    fun testNegativeInfiniteSpeed() {
+        val clipSpec = LottieClipSpec.Progress(0.33f, 0.57f)
+        runTest {
+            launch {
+                anim.animate(composition, clipSpec = clipSpec, speed = Float.NEGATIVE_INFINITY, iterations = LottieConstants.IterateForever)
+            }
+            assertFrame(
+                0,
+                progress = 0.33f,
+                isPlaying = false,
+                speed = Float.NEGATIVE_INFINITY,
+                clipSpec = clipSpec,
+                isAtEnd = true,
+                iterations = LottieConstants.IterateForever,
+                iteration = LottieConstants.IterateForever,
+                lastFrameNanos = AnimationConstants.UnspecifiedTime,
+            )
+        }
+    }
+
+
+    @Test
     fun testNonCancellable() = runTest {
         val job = launch {
             anim.animate(composition, cancellationBehavior = LottieCancellationBehavior.OnIterationFinish)


### PR DESCRIPTION
This will _only_ automatically work for `animateLottieCompositionAsState(...)` because accessing the system animator scale requires a Context and the coroutines `LottieAnimatable` functions don't have access to that. Apps will need to manually handle the scale if they aren't using `animateLottieCompositionAsState(...)`.

When animations are disabled, the speed becomes infinite and Lottie will jump to the end of the animation.

Fixes https://github.com/airbnb/lottie-android/issues/1906