### PR TITLE
Check composition exists when using software rendering

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -1354,6 +1354,9 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    * @see LottieAnimationView#setRenderMode(RenderMode)
    */
   private void renderAndDrawAsBitmap(Canvas originalCanvas, CompositionLayer compositionLayer) {
+    if (composition == null || compositionLayer == null) {
+      return;
+    }
     ensureSoftwareRenderingObjectsInitialized();
 
     //noinspection deprecation


### PR DESCRIPTION
To reproduce crash, add the following to the IssueReproActivity:
```
binding.animationView.setCacheComposition(false)
binding.animationView.renderMode = RenderMode.SOFTWARE
binding.animationView.postDelayed({ binding.animationView.setAnimation(R.raw.heart) }, 1000)
```

When it tries to render with null composition, `getIntrinsicWidth()` and `getIntrinsicHeight()` return `-1`, and both `renderWidth` and `renderHeight` end up being negative, which results in a crash:
```
    java.lang.IllegalArgumentException: width must be > 0
        at android.graphics.Bitmap.checkWidthHeight(Bitmap.java:378)
        at android.graphics.Bitmap.createBitmap(Bitmap.java:684)
        at android.graphics.Bitmap.createBitmap(Bitmap.java:653)
        at com.airbnb.lottie.LottieDrawable.ensureSoftwareRenderingBitmap(LottieDrawable.java:1452)
        at com.airbnb.lottie.LottieDrawable.renderAndDrawAsBitmap(LottieDrawable.java:1400)
        at com.airbnb.lottie.LottieDrawable.draw(LottieDrawable.java:515)
```
It does not crash if renderMode is hardware.

Fixes #2026