### PR TITLE
Fixing memory leak of ShowcaseFragment

### DIFF
--- a/sample/src/main/kotlin/com/airbnb/lottie/samples/ShowcaseFragment.kt
+++ b/sample/src/main/kotlin/com/airbnb/lottie/samples/ShowcaseFragment.kt
@@ -41,19 +41,19 @@ class ShowcaseFragment : BaseEpoxyFragment() {
 
     private val showcaseItems = listOf(
         ShowcaseItem(R.drawable.showcase_preview_lottie, R.string.showcase_item_dynamic_properties) {
-            startActivity(Intent(requireContext(), DynamicActivity::class.java))
+            it.startActivity(Intent(it, DynamicActivity::class.java))
         },
         ShowcaseItem(R.drawable.gilbert_animated, R.string.showcase_item_animated_text) {
-            startActivity(Intent(requireContext(), TypographyDemoActivity::class.java))
+            it.startActivity(Intent(it, TypographyDemoActivity::class.java))
         },
         ShowcaseItem(R.drawable.gilbert_animated, R.string.showcase_item_dynamic_text) {
-            startActivity(Intent(requireContext(), DynamicTextActivity::class.java))
+            it.startActivity(Intent(it, DynamicTextActivity::class.java))
         },
         ShowcaseItem(R.drawable.showcase_preview_lottie, R.string.showcase_item_bullseye) {
-            startActivity(Intent(requireContext(), BullseyeActivity::class.java))
+            it.startActivity(Intent(it, BullseyeActivity::class.java))
         },
         ShowcaseItem(R.drawable.showcase_preview_lottie, R.string.showcase_item_recycler_view) {
-            startActivity(Intent(requireContext(), WishListActivity::class.java))
+            it.startActivity(Intent(it, WishListActivity::class.java))
         }
     )
     private val viewModel: ShowcaseViewModel by fragmentViewModel()

--- a/sample/src/main/kotlin/com/airbnb/lottie/samples/ShowcaseFragment.kt
+++ b/sample/src/main/kotlin/com/airbnb/lottie/samples/ShowcaseFragment.kt
@@ -76,12 +76,13 @@ class ShowcaseFragment : BaseEpoxyFragment() {
             }
         } else {
             collectionItems.forEach {
+                val activityContext = requireActivity()
                 animationItemView {
                     id(it.id)
                     title(it.title)
                     if (it.preview != null) previewUrl("https://assets9.lottiefiles.com/${it.preview}")
                     previewBackgroundColor(it.bgColorInt)
-                    onClickListener { _ -> startActivity(PlayerActivity.intent(requireContext(), CompositionArgs(animationDataV2 = it))) }
+                    onClickListener { _ -> activityContext.startActivity(PlayerActivity.intent(activityContext, CompositionArgs(animationDataV2 = it))) }
                 }
             }
         }

--- a/sample/src/main/kotlin/com/airbnb/lottie/samples/model/ShowcaseItem.kt
+++ b/sample/src/main/kotlin/com/airbnb/lottie/samples/model/ShowcaseItem.kt
@@ -1,10 +1,11 @@
 package com.airbnb.lottie.samples.model
 
+import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 
 data class ShowcaseItem(
     @DrawableRes val drawableRes: Int,
     @StringRes val titleRes: Int,
-    val clickListener: () -> Unit
+    val clickListener: (context: Context) -> Unit
 )

--- a/sample/src/main/kotlin/com/airbnb/lottie/samples/views/ShowcaseDemoItemView.kt
+++ b/sample/src/main/kotlin/com/airbnb/lottie/samples/views/ShowcaseDemoItemView.kt
@@ -23,6 +23,6 @@ class ShowcaseDemoItemView @JvmOverloads constructor(
 
         binding.titleView.text = resources.getText(item.titleRes)
 
-        binding.cardView.setOnClickListener { item.clickListener() }
+        binding.cardView.setOnClickListener { item.clickListener(this.context.applicationContext) }
     }
 }


### PR DESCRIPTION
This PR fixes #2029 which refers to two memory leaks leading to the leak of `ShowcaseFragment`.

## Changelog

* For fixing 1st memory leak in the issue we have used `requireActivity` inside for each loop as an explicit field outside the lambda which introduces a synthetic field of activity thus avoiding leak. You can compare this with the previous screenshot attached to the [issue](https://github.com/airbnb/lottie-android/issues/2029). This is inside [this](https://github.com/airbnb/lottie-android/commit/5d0893a82ed376967900bdb9323216994ee64de0) commit.

![Screenshot 2022-03-02 at 5 02 11 PM](https://user-images.githubusercontent.com/12881364/156354519-8feb7dfe-d26e-47be-9e8e-9f58f4632cbd.png)


* For fixing 2nd memory leak we have added explicit context as a parameter in `clickListener` high order function field of `ShowcaseItem`. Correctly passing the application context to this removes the memory leak. This is inside [this](f2186776d123398272133489430a02bb15aa4224) commit.
