### PR TITLE
Add FILTER_BITMAP_FLAG for software rendering

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -1433,7 +1433,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     softwareRenderingOriginalCanvasMatrixInverse = new Matrix();
     canvasClipBounds = new Rect();
     canvasClipBoundsRectF = new RectF();
-    softwareRenderingPaint = new LPaint();
+    softwareRenderingPaint = new LPaint(Paint.FILTER_BITMAP_FLAG);
     softwareRenderingSrcBoundsRect = new Rect();
     softwareRenderingDstBoundsRect = new Rect();
     softwareRenderingDstBoundsRectF = new RectF();


### PR DESCRIPTION
On older devices (pre-O) if software rendering was used and the animation had to be scaled, it could lead to aliasing artifacts like this:
![image](https://user-images.githubusercontent.com/1307745/160498046-d7654166-22ec-4bf4-9f52-e5c0c573660b.png)

Adding this flag fixed the artifacts.


EDIT: going to investigate if it's possible to get the src/dst drawing rects to not scale when drawing the bitmap.