### PR TITLE
Support completable animations in Compose tests

### DIFF
--- a/sample-compose/src/androidTest/java/com/airbnb/lottie/samples/WalkthroughAnimationTest.kt
+++ b/sample-compose/src/androidTest/java/com/airbnb/lottie/samples/WalkthroughAnimationTest.kt
@@ -1,0 +1,46 @@
+package com.airbnb.lottie.samples
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.airbnb.lottie.LottieCompositionFactory
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.animateLottieCompositionAsState
+import com.airbnb.lottie.sample.compose.ComposeActivity
+import com.airbnb.lottie.sample.compose.R
+import org.junit.Rule
+import org.junit.Test
+
+class WalkthroughAnimationTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule(ComposeActivity::class.java)
+
+    @Test
+    fun testWalkthroughCompletes() {
+        val composition = LottieCompositionFactory.fromRawResSync(composeTestRule.activity, R.raw.walkthrough).value!!
+        var animationCompleted = true
+
+        composeTestRule.setContent {
+            val progress by animateLottieCompositionAsState(composition, iterations = 1)
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                LottieAnimation(
+                    composition,
+                    progress,
+                )
+            }
+
+            if (progress == 1f) {
+                animationCompleted = true
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeUntil { animationCompleted }
+    }
+}


### PR DESCRIPTION
The change in #1987 to always use `withInfiniteAnimationFrameNanos` prevents non-infinite animations from completing in Compose tests. 

I added a simple check to use `withFrameNanos` or `withInfiniteAnimationFrameNanos` based on the number of iterations. This fixes tests that wait for animations to complete, see sample `WalkthroughAnimationTest`. And `InfiniteAnimationTest` still passes.

Let me know if I'm missing some other use case.