### PR TITLE
Fix LottieDrawable#start for non-View callbacks

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -551,7 +551,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   public void start() {
     // Don't auto play when in edit mode.
     Callback callback = getCallback();
-    if (callback instanceof View && !((View) callback).isInEditMode()) {
+    if (!(callback instanceof View) || !((View) callback).isInEditMode()) {
       playAnimation();
     }
   }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -549,11 +549,12 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
   @MainThread
   @Override
   public void start() {
-    // Don't auto play when in edit mode.
     Callback callback = getCallback();
-    if (!(callback instanceof View) || !((View) callback).isInEditMode()) {
-      playAnimation();
+    if (callback instanceof View && ((View) callback).isInEditMode()) {
+      // Don't auto play when in edit mode.
+      return;
     }
+    playAnimation();
   }
 
   @MainThread


### PR DESCRIPTION
Previously, the start function would be a noop if your callback was something other than a View instance.

With this change, if you use a non-View Callback (such as a Drawable), start will still call playAnimation; if the Callback was a View, it must still not be in edit mode to call playAnimation.