### PR TITLE
Fix references to Store in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,11 +2,11 @@
 
 ## 1. Purpose
 
-A primary goal of Store is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+A primary goal of Lottie is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
 
 This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
 
-We invite all those who participate in Store to help us create safe and positive experiences for everyone.
+We invite all those who participate in Lottie to help us create safe and positive experiences for everyone.
 
 ## 2. Open Source Citizenship
 


### PR DESCRIPTION
I assume these were copy-paste errors, so I just replaced the mentions of Store to Lottie, since I assume that was unintended. :)