### PR TITLE
Clear onVisibleAction once the action is taken

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -583,6 +583,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     if (animationsEnabled() || getRepeatCount() == 0) {
       if (isVisible()) {
         animator.playAnimation();
+        onVisibleAction = OnVisibleAction.NONE;
       } else {
         onVisibleAction = OnVisibleAction.PLAY;
       }
@@ -620,6 +621,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     if (animationsEnabled() || getRepeatCount() == 0) {
       if (isVisible()) {
         animator.resumeAnimation();
+        onVisibleAction = OnVisibleAction.NONE;
       } else {
         onVisibleAction = OnVisibleAction.RESUME;
       }


### PR DESCRIPTION
The root cause of #2053 is that once the fragment was paused and resumed, the onResumeAction was set to RESUME and never cleared. The compass view in the linked project triggered a relayout on every frame which caused the visibility action run over and over again. The animation itself happens to have an empty first frame so it appeared as if the animation disappeared.

Fixes #2053 