### PR TITLE
Add fontStyle argument for FontAssetDelegate

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/FontAssetDelegate.java
+++ b/lottie/src/main/java/com/airbnb/lottie/FontAssetDelegate.java
@@ -11,16 +11,16 @@ import android.graphics.Typeface;
 @SuppressWarnings({"unused", "WeakerAccess"}) public class FontAssetDelegate {
 
   /**
-   * Override this if you want to return a Typeface from a font family.
+   * Override this if you want to return a Typeface from a font family and style.
    */
-  public Typeface fetchFont(String fontFamily) {
+  public Typeface fetchFont(String fontFamily, String fontStyle) {
     return null;
   }
 
   /**
    * Override this if you want to specify the asset path for a given font family.
    */
-  public String getFontPath(String fontFamily) {
+  public String getFontPath(String fontFamily, String fontStyle) {
     return null;
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/manager/FontAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/FontAssetManager.java
@@ -76,12 +76,13 @@ public class FontAssetManager {
     }
 
     Typeface typeface = null;
+    String fontStyle = font.getStyle();
     if (delegate != null) {
-      typeface = delegate.fetchFont(fontFamily);
+      typeface = delegate.fetchFont(fontFamily, fontStyle);
     }
 
     if (delegate != null && typeface == null) {
-      String path = delegate.getFontPath(fontFamily);
+      String path = delegate.getFontPath(fontFamily, fontStyle);
       if (path != null) {
         typeface = Typeface.createFromAsset(assetManager, path);
       }


### PR DESCRIPTION
In my case, using FontAssetDelegate to listen `fetchFont(fontFamily)` was not enough to know what font to load.

For example, I got `fontFamily == "Roboto"` but don't know the font style is `Black`. This PR will solve this problem.