### PR TITLE
Fix ImageAssetManager.bitmapForId NPE crash

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -121,6 +121,10 @@ public class ImageAssetManager {
       Logger.warning("Unable to decode image.", e);
       return null;
     }
+    if (bitmap == null) {
+        Logger.warning("Decoded image is NULL.");
+        return null;
+    }
     bitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
     return putBitmap(id, bitmap);
   }


### PR DESCRIPTION
In method ImageAssetManager.bitmapForId, if BitmapFactory.decodeStream returned null, so NPE crash happened. And we can see this is a legal return value in android docs, So I fixed it.