### PR TITLE
Fix ImageAssetManager.bitmapForId NPE crash

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -122,8 +122,8 @@ public class ImageAssetManager {
       return null;
     }
     if (bitmap == null) {
-        Logger.warning("Decoded image is NULL.");
-        return null;
+      Logger.warning("Decoded image `" + id + "` is null.");
+      return null;
     }
     bitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
     return putBitmap(id, bitmap);

--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -121,6 +121,10 @@ public class ImageAssetManager {
       Logger.warning("Unable to decode image.", e);
       return null;
     }
+    if (bitmap == null) {
+        Logger.warning("Decoded image is NULL.");
+        return null;
+    }
     bitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
     return putBitmap(id, bitmap);
   }

--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -118,7 +118,7 @@ public class ImageAssetManager {
     try {
       bitmap = BitmapFactory.decodeStream(is, null, opts);
     } catch (IllegalArgumentException e) {
-      Logger.warning("Unable to decode image.", e);
+      Logger.warning("Unable to decode image `" + id + "`.", e);
       return null;
     }
     if (bitmap == null) {


### PR DESCRIPTION
In Android docs, BitmapFactory.decodeStream may return NULL, This is a legal return value, we did not deal with it, NPE may occur in some cases. So I fixed it.