### PR TITLE
Add the LottieConfig.Builder.setEnableNetworkCache() method to completely disable internal network cache if needed

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/L.java
+++ b/lottie/src/main/java/com/airbnb/lottie/L.java
@@ -3,6 +3,7 @@ package com.airbnb.lottie;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.core.os.TraceCompat;
 
@@ -22,6 +23,7 @@ public class L {
 
   private static final int MAX_DEPTH = 20;
   private static boolean traceEnabled = false;
+  private static boolean networkCacheEnabled = true;
   private static String[] sections;
   private static long[] startTimeNs;
   private static int traceDepth = 0;
@@ -45,6 +47,10 @@ public class L {
       sections = new String[MAX_DEPTH];
       startTimeNs = new long[MAX_DEPTH];
     }
+  }
+
+  public static void setNetworkCacheEnabled(boolean enabled) {
+    networkCacheEnabled = enabled;
   }
 
   public static void beginSection(String section) {
@@ -103,8 +109,11 @@ public class L {
     return local;
   }
 
-  @NonNull
+  @Nullable
   public static NetworkCache networkCache(@NonNull final Context context) {
+    if (!networkCacheEnabled) {
+      return null;
+    }
     final Context appContext = context.getApplicationContext();
     NetworkCache local = networkCache;
     if (local == null) {

--- a/lottie/src/main/java/com/airbnb/lottie/Lottie.java
+++ b/lottie/src/main/java/com/airbnb/lottie/Lottie.java
@@ -19,5 +19,6 @@ public class Lottie {
     L.setFetcher(lottieConfig.networkFetcher);
     L.setCacheProvider(lottieConfig.cacheProvider);
     L.setTraceEnabled(lottieConfig.enableSystraceMarkers);
+    L.setNetworkCacheEnabled(lottieConfig.enableNetworkCache);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -18,6 +18,7 @@ import androidx.annotation.WorkerThread;
 
 import com.airbnb.lottie.model.Font;
 import com.airbnb.lottie.model.LottieCompositionCache;
+import com.airbnb.lottie.network.NetworkCache;
 import com.airbnb.lottie.parser.LottieCompositionMoshiParser;
 import com.airbnb.lottie.parser.moshi.JsonReader;
 import com.airbnb.lottie.utils.Logger;
@@ -27,7 +28,6 @@ import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -80,7 +80,10 @@ public class LottieCompositionFactory {
   public static void clearCache(Context context) {
     taskCache.clear();
     LottieCompositionCache.getInstance().clear();
-    L.networkCache(context).clear();
+    final NetworkCache networkCache = L.networkCache(context);
+    if (networkCache != null) {
+      networkCache.clear();
+    }
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/LottieConfig.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieConfig.java
@@ -18,12 +18,14 @@ public class LottieConfig {
   @Nullable final LottieNetworkFetcher networkFetcher;
   @Nullable final LottieNetworkCacheProvider cacheProvider;
   final boolean enableSystraceMarkers;
+  final boolean enableNetworkCache;
 
   private LottieConfig(@Nullable LottieNetworkFetcher networkFetcher, @Nullable LottieNetworkCacheProvider cacheProvider,
-      boolean enableSystraceMarkers) {
+      boolean enableSystraceMarkers, boolean enableNetworkCache) {
     this.networkFetcher = networkFetcher;
     this.cacheProvider = cacheProvider;
     this.enableSystraceMarkers = enableSystraceMarkers;
+    this.enableNetworkCache = enableNetworkCache;
   }
 
   public static final class Builder {
@@ -33,6 +35,7 @@ public class LottieConfig {
     @Nullable
     private LottieNetworkCacheProvider cacheProvider;
     private boolean enableSystraceMarkers = false;
+    private boolean enableNetworkCache = true;
 
     /**
      * Lottie has a default network fetching stack built on {@link java.net.HttpURLConnection}. However, if you would like to hook into your own
@@ -98,9 +101,19 @@ public class LottieConfig {
       return this;
     }
 
+    /**
+     * Disable this if you want to completely disable internal Lottie cache for retrieving network animations.
+     * Internal network cache is enabled by default.
+     */
+    @NonNull
+    public Builder setEnableNetworkCache(boolean enable) {
+      enableNetworkCache = enable;
+      return this;
+    }
+
     @NonNull
     public LottieConfig build() {
-      return new LottieConfig(networkFetcher, cacheProvider, enableSystraceMarkers);
+      return new LottieConfig(networkFetcher, cacheProvider, enableSystraceMarkers, enableNetworkCache);
     }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
@@ -22,12 +22,12 @@ import java.util.zip.ZipInputStream;
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class NetworkFetcher {
 
-  @NonNull
+  @Nullable
   private final NetworkCache networkCache;
   @NonNull
   private final LottieNetworkFetcher fetcher;
 
-  public NetworkFetcher(@NonNull NetworkCache networkCache, @NonNull LottieNetworkFetcher fetcher) {
+  public NetworkFetcher(@Nullable NetworkCache networkCache, @NonNull LottieNetworkFetcher fetcher) {
     this.networkCache = networkCache;
     this.fetcher = fetcher;
   }
@@ -48,7 +48,7 @@ public class NetworkFetcher {
   @Nullable
   @WorkerThread
   private LottieComposition fetchFromCache(Context context, @NonNull String url, @Nullable String cacheKey) {
-    if (cacheKey == null) {
+    if (cacheKey == null || networkCache == null) {
       return null;
     }
     Pair<FileExtension, InputStream> cacheResult = networkCache.fetch(url);
@@ -123,7 +123,7 @@ public class NetworkFetcher {
       result = fromJsonStream(url, inputStream, cacheKey);
     }
 
-    if (cacheKey != null && result.getValue() != null) {
+    if (cacheKey != null && result.getValue() != null && networkCache != null) {
       networkCache.renameTempFile(url, extension);
     }
 
@@ -133,7 +133,7 @@ public class NetworkFetcher {
   @NonNull
   private LottieResult<LottieComposition> fromZipStream(Context context, @NonNull String url, @NonNull InputStream inputStream, @Nullable String cacheKey)
       throws IOException {
-    if (cacheKey == null) {
+    if (cacheKey == null || networkCache == null) {
       return LottieCompositionFactory.fromZipStreamSync(context, new ZipInputStream(inputStream), null);
     }
     File file = networkCache.writeTempCacheFile(url, inputStream, FileExtension.ZIP);
@@ -143,7 +143,7 @@ public class NetworkFetcher {
   @NonNull
   private LottieResult<LottieComposition> fromJsonStream(@NonNull String url, @NonNull InputStream inputStream, @Nullable String cacheKey)
       throws IOException {
-    if (cacheKey == null) {
+    if (cacheKey == null || networkCache == null) {
       return LottieCompositionFactory.fromJsonInputStreamSync(inputStream, null);
     }
     File file = networkCache.writeTempCacheFile(url, inputStream, FileExtension.JSON);


### PR DESCRIPTION
**Rationale**
We'd like to implement more sophisticated caching strategy for animations fetched from network. This could be implemented on the network fetcher level e.g. using the OkHttp's cache or the "stale-while-revalidate" strategy.
For this to work the internal Lottie network cache has to be completely disabled.
The option to do so is implemented in this PR.

**Implementation**
By default the internal cache is enabled to maintain backward compatibility. 
We've added the `LottieConfig.Builder.setEnableNetworkCache()` method to override the default behavior.