### PR TITLE
Pass LottieComposition to all content when it is generated

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/ContentGroup.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/ContentGroup.java
@@ -8,6 +8,7 @@ import android.graphics.RectF;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.LPaint;
 import com.airbnb.lottie.animation.keyframe.BaseKeyframeAnimation;
@@ -30,11 +31,11 @@ public class ContentGroup implements DrawingContent, PathContent,
   private final Paint offScreenPaint = new LPaint();
   private final RectF offScreenRectF = new RectF();
 
-  private static List<Content> contentsFromModels(LottieDrawable drawable, BaseLayer layer,
+  private static List<Content> contentsFromModels(LottieDrawable drawable, LottieComposition composition, BaseLayer layer,
       List<ContentModel> contentModels) {
     List<Content> contents = new ArrayList<>(contentModels.size());
     for (int i = 0; i < contentModels.size(); i++) {
-      Content content = contentModels.get(i).toContent(drawable, layer);
+      Content content = contentModels.get(i).toContent(drawable, composition, layer);
       if (content != null) {
         contents.add(content);
       }
@@ -63,9 +64,9 @@ public class ContentGroup implements DrawingContent, PathContent,
   @Nullable private List<PathContent> pathContents;
   @Nullable private TransformKeyframeAnimation transformAnimation;
 
-  public ContentGroup(final LottieDrawable lottieDrawable, BaseLayer layer, ShapeGroup shapeGroup) {
+  public ContentGroup(final LottieDrawable lottieDrawable, BaseLayer layer, ShapeGroup shapeGroup, LottieComposition composition) {
     this(lottieDrawable, layer, shapeGroup.getName(),
-        shapeGroup.isHidden(), contentsFromModels(lottieDrawable, layer, shapeGroup.getItems()),
+        shapeGroup.isHidden(), contentsFromModels(lottieDrawable, composition, layer, shapeGroup.getItems()),
         findTransform(shapeGroup.getItems()));
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/GradientFillContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/GradientFillContent.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 import androidx.collection.LongSparseArray;
 
 import com.airbnb.lottie.L;
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.LottieProperty;
 import com.airbnb.lottie.animation.LPaint;
@@ -64,14 +65,14 @@ public class GradientFillContent
   float blurMaskFilterRadius = 0f;
   @Nullable private DropShadowKeyframeAnimation dropShadowAnimation;
 
-  public GradientFillContent(final LottieDrawable lottieDrawable, BaseLayer layer, GradientFill fill) {
+  public GradientFillContent(final LottieDrawable lottieDrawable, LottieComposition composition, BaseLayer layer, GradientFill fill) {
     this.layer = layer;
     name = fill.getName();
     hidden = fill.isHidden();
     this.lottieDrawable = lottieDrawable;
     type = fill.getGradientType();
     path.setFillType(fill.getFillType());
-    cacheSteps = (int) (lottieDrawable.getComposition().getDuration() / CACHE_STEPS_MS);
+    cacheSteps = (int) (composition.getDuration() / CACHE_STEPS_MS);
 
     colorAnimation = fill.getGradientColor().createAnimation();
     colorAnimation.addUpdateListener(this);

--- a/lottie/src/main/java/com/airbnb/lottie/model/animatable/AnimatableTransform.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/animatable/AnimatableTransform.java
@@ -4,6 +4,7 @@ import android.graphics.PointF;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.ModifierContent;
@@ -104,7 +105,7 @@ public class AnimatableTransform implements ModifierContent, ContentModel {
 
   @Nullable
   @Override
-  public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return null;
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/CircleShape.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/CircleShape.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.model.content;
 
 import android.graphics.PointF;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.EllipseContent;
@@ -25,7 +26,7 @@ public class CircleShape implements ContentModel {
     this.hidden = hidden;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new EllipseContent(drawable, layer, this);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/ContentModel.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/ContentModel.java
@@ -3,10 +3,11 @@ package com.airbnb.lottie.model.content;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.model.layer.BaseLayer;
 
 public interface ContentModel {
-  @Nullable Content toContent(LottieDrawable drawable, BaseLayer layer);
+  @Nullable Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer);
 }

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/GradientFill.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/GradientFill.java
@@ -4,6 +4,7 @@ import android.graphics.Path;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.GradientFillContent;
@@ -75,8 +76,8 @@ public class GradientFill implements ContentModel {
     return hidden;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
-    return new GradientFillContent(drawable, layer, this);
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
+    return new GradientFillContent(drawable, composition, layer, this);
   }
 
 }

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/GradientStroke.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/GradientStroke.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.model.content;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.GradientStrokeContent;
@@ -103,7 +104,7 @@ public class GradientStroke implements ContentModel {
     return hidden;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new GradientStrokeContent(drawable, layer, this);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/MergePaths.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/MergePaths.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.model.content;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.MergePathsContent;
@@ -58,7 +59,7 @@ public class MergePaths implements ContentModel {
     return hidden;
   }
 
-  @Override @Nullable public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override @Nullable public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     if (!drawable.enableMergePathsForKitKatAndAbove()) {
       Logger.warning("Animation contains merge paths but they are disabled.");
       return null;

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/PolystarShape.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/PolystarShape.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.model.content;
 
 import android.graphics.PointF;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.PolystarContent;
@@ -104,7 +105,7 @@ public class PolystarShape implements ContentModel {
     return isReversed;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new PolystarContent(drawable, layer, this);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/RectangleShape.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/RectangleShape.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.model.content;
 
 import android.graphics.PointF;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.RectangleContent;
@@ -45,7 +46,7 @@ public class RectangleShape implements ContentModel {
     return hidden;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new RectangleContent(drawable, layer, this);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/Repeater.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/Repeater.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.model.content;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.RepeaterContent;
@@ -45,7 +46,7 @@ public class Repeater implements ContentModel {
     return hidden;
   }
 
-  @Nullable @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Nullable @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new RepeaterContent(drawable, layer, this);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/RoundedCorners.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/RoundedCorners.java
@@ -2,6 +2,7 @@ package com.airbnb.lottie.model.content;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.RoundedCornersContent;
@@ -25,7 +26,7 @@ public class RoundedCorners implements ContentModel {
     return cornerRadius;
   }
 
-  @Nullable @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Nullable @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new RoundedCornersContent(drawable, layer, this);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/ShapeFill.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/ShapeFill.java
@@ -4,6 +4,7 @@ import android.graphics.Path;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.FillContent;
@@ -49,7 +50,7 @@ public class ShapeFill implements ContentModel {
     return hidden;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new FillContent(drawable, layer, this);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/ShapeGroup.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/ShapeGroup.java
@@ -1,5 +1,6 @@
 package com.airbnb.lottie.model.content;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.ContentGroup;
@@ -31,8 +32,8 @@ public class ShapeGroup implements ContentModel {
     return hidden;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
-    return new ContentGroup(drawable, layer, this);
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
+    return new ContentGroup(drawable, layer, this, composition);
   }
 
   @Override public String toString() {

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/ShapePath.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/ShapePath.java
@@ -1,5 +1,6 @@
 package com.airbnb.lottie.model.content;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.ShapeContent;
@@ -27,7 +28,7 @@ public class ShapePath implements ContentModel {
     return shapePath;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new ShapeContent(drawable, layer, this);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/ShapeStroke.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/ShapeStroke.java
@@ -4,6 +4,7 @@ import android.graphics.Paint;
 
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.StrokeContent;
@@ -78,7 +79,7 @@ public class ShapeStroke implements ContentModel {
     this.hidden = hidden;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new StrokeContent(drawable, layer, this);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/content/ShapeTrimPath.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/content/ShapeTrimPath.java
@@ -1,5 +1,6 @@
 package com.airbnb.lottie.model.content;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.TrimPathContent;
@@ -65,7 +66,7 @@ public class ShapeTrimPath implements ContentModel {
     return hidden;
   }
 
-  @Override public Content toContent(LottieDrawable drawable, BaseLayer layer) {
+  @Override public Content toContent(LottieDrawable drawable, LottieComposition composition, BaseLayer layer) {
     return new TrimPathContent(layer, this);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -55,7 +55,7 @@ public abstract class BaseLayer
       CompositionLayer compositionLayer, Layer layerModel, LottieDrawable drawable, LottieComposition composition) {
     switch (layerModel.getLayerType()) {
       case SHAPE:
-        return new ShapeLayer(drawable, layerModel, compositionLayer);
+        return new ShapeLayer(drawable, layerModel, compositionLayer, composition);
       case PRE_COMP:
         return new CompositionLayer(drawable, layerModel,
             composition.getPrecomps(layerModel.getRefId()), composition);

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/ShapeLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/ShapeLayer.java
@@ -7,6 +7,7 @@ import android.graphics.RectF;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.airbnb.lottie.LottieComposition;
 import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.ContentGroup;
@@ -22,13 +23,13 @@ public class ShapeLayer extends BaseLayer {
   private final ContentGroup contentGroup;
   private final CompositionLayer compositionLayer;
 
-  ShapeLayer(LottieDrawable lottieDrawable, Layer layerModel, CompositionLayer compositionLayer) {
+  ShapeLayer(LottieDrawable lottieDrawable, Layer layerModel, CompositionLayer compositionLayer, LottieComposition composition) {
     super(lottieDrawable, layerModel);
     this.compositionLayer = compositionLayer;
 
     // Naming this __container allows it to be ignored in KeyPath matching.
     ShapeGroup shapeGroup = new ShapeGroup("__container", layerModel.getShapes(), false);
-    contentGroup = new ContentGroup(lottieDrawable, this, shapeGroup);
+    contentGroup = new ContentGroup(lottieDrawable, this, shapeGroup, composition);
     contentGroup.setContents(Collections.<Content>emptyList(), Collections.<Content>emptyList());
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
@@ -426,7 +426,7 @@ public class TextLayer extends BaseLayer {
     List<ContentGroup> contents = new ArrayList<>(size);
     for (int i = 0; i < size; i++) {
       ShapeGroup sg = shapes.get(i);
-      contents.add(new ContentGroup(lottieDrawable, this, sg));
+      contents.add(new ContentGroup(lottieDrawable, this, sg, composition));
     }
     contentsForCharacter.put(character, contents);
     return contents;


### PR DESCRIPTION
This allows GradientFill to access the composition directly. Previously, when accessed through LottieDrawable, there was a potential race condition that caused LottieDrawable.getComposition() to be set to something else externally before the GradientFill content was able to access it.

Fixes #2159 