### PR TITLE
Add NPE protections around transform opacity

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -241,9 +241,18 @@ public abstract class BaseLayer
       matrix.preConcat(parentLayers.get(i).transform.getMatrix());
     }
     L.endSection("Layer#parentMatrix");
-    int opacity = transform.getOpacity() == null ? 100 : transform.getOpacity().getValue();
-    int alpha = (int)
-        ((parentAlpha / 255f * (float) opacity / 100f) * 255);
+    // It is unclear why but getting the opacity here would sometimes NPE.
+    // The extra code here is designed to avoid this.
+    // https://github.com/airbnb/lottie-android/issues/2083
+    int opacity = 100;
+    BaseKeyframeAnimation<?, Integer> opacityAnimation = transform.getOpacity();
+    if (opacityAnimation != null) {
+      Integer opacityValue = opacityAnimation.getValue();
+      if (opacityValue != null) {
+        opacity = opacityValue;
+      }
+    }
+    int alpha = (int) ((parentAlpha / 255f * (float) opacity / 100f) * 255);
     if (!hasMatteOnThisLayer() && !hasMasksOnThisLayer()) {
       matrix.preConcat(transform.getMatrix());
       L.beginSection("Layer#drawLayer");


### PR DESCRIPTION
It isn't clear why the underlying issue is happening but if it's isolated and device specific, it's easier to add this harmless checking code rather than get to the bottom of this one.

Fixes https://github.com/airbnb/lottie-android/issues/2083