### PR TITLE
[Snapshot tests] Only set a font asset delegate when there are no glyphs

### DIFF
--- a/snapshot-tests/src/androidTest/java/com/airbnb/lottie/snapshots/SnapshotTestCaseContext.kt
+++ b/snapshot-tests/src/androidTest/java/com/airbnb/lottie/snapshots/SnapshotTestCaseContext.kt
@@ -145,11 +145,13 @@ suspend fun SnapshotTestCaseContext.snapshotComposition(
     filmStripView.setOutlineMasksAndMattes(false)
     filmStripView.setApplyingOpacityToLayersEnabled(false)
     filmStripView.setImageAssetDelegate { BitmapFactory.decodeResource(context.resources, R.drawable.airbnb) }
-    filmStripView.setFontAssetDelegate(object : FontAssetDelegate() {
-        override fun getFontPath(fontFamily: String?, fontStyle: String?, fontName: String?): String {
-            return "fonts/Roboto.ttf"
-        }
-    })
+    if (composition.characters.isEmpty) {
+        filmStripView.setFontAssetDelegate(object : FontAssetDelegate() {
+            override fun getFontPath(fontFamily: String?, fontStyle: String?, fontName: String?): String {
+                return "fonts/Roboto.ttf"
+            }
+        })
+    }
     callback?.invoke(filmStripView)
     val spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
     filmStripView.measure(spec, spec)


### PR DESCRIPTION
This should give better test coverage of glyphs and font rendering.