### PR TITLE
Make Layer name and refId public

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/Layer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/Layer.java
@@ -116,11 +116,11 @@ public class Layer {
     return layerId;
   }
 
-  String getName() {
+  public String getName() {
     return layerName;
   }
 
-  @Nullable String getRefId() {
+  public @Nullable String getRefId() {
     return refId;
   }
 


### PR DESCRIPTION
I'm running tests against my animation json files and I want to make sure that all the layers I expect to be there are actually there, but I'm hitting issues with the visibility of these two functions.