### PR TITLE
[Snapshot tests] Disable the path interpolator cache

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/L.java
+++ b/lottie/src/main/java/com/airbnb/lottie/L.java
@@ -24,6 +24,7 @@ public class L {
   private static final int MAX_DEPTH = 20;
   private static boolean traceEnabled = false;
   private static boolean networkCacheEnabled = true;
+  private static boolean disablePathInterpolatorCache = true;
   private static String[] sections;
   private static long[] startTimeNs;
   private static int traceDepth = 0;
@@ -129,5 +130,13 @@ public class L {
       }
     }
     return local;
+  }
+
+  public static void setDisablePathInterpolatorCache(boolean disablePathInterpolatorCache) {
+    L.disablePathInterpolatorCache = disablePathInterpolatorCache;
+  }
+
+  public static boolean getDisablePathInterpolatorCache() {
+    return disablePathInterpolatorCache;
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/Lottie.java
+++ b/lottie/src/main/java/com/airbnb/lottie/Lottie.java
@@ -20,5 +20,7 @@ public class Lottie {
     L.setCacheProvider(lottieConfig.cacheProvider);
     L.setTraceEnabled(lottieConfig.enableSystraceMarkers);
     L.setNetworkCacheEnabled(lottieConfig.enableNetworkCache);
+    L.setNetworkCacheEnabled(lottieConfig.enableNetworkCache);
+    L.setDisablePathInterpolatorCache(lottieConfig.disablePathInterpolatorCache);
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieConfig.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieConfig.java
@@ -19,13 +19,15 @@ public class LottieConfig {
   @Nullable final LottieNetworkCacheProvider cacheProvider;
   final boolean enableSystraceMarkers;
   final boolean enableNetworkCache;
+  final boolean disablePathInterpolatorCache;
 
   private LottieConfig(@Nullable LottieNetworkFetcher networkFetcher, @Nullable LottieNetworkCacheProvider cacheProvider,
-      boolean enableSystraceMarkers, boolean enableNetworkCache) {
+      boolean enableSystraceMarkers, boolean enableNetworkCache, boolean disablePathInterpolatorCache) {
     this.networkFetcher = networkFetcher;
     this.cacheProvider = cacheProvider;
     this.enableSystraceMarkers = enableSystraceMarkers;
     this.enableNetworkCache = enableNetworkCache;
+    this.disablePathInterpolatorCache = disablePathInterpolatorCache;
   }
 
   public static final class Builder {
@@ -36,6 +38,7 @@ public class LottieConfig {
     private LottieNetworkCacheProvider cacheProvider;
     private boolean enableSystraceMarkers = false;
     private boolean enableNetworkCache = true;
+    private boolean disablePathInterpolatorCache = true;
 
     /**
      * Lottie has a default network fetching stack built on {@link java.net.HttpURLConnection}. However, if you would like to hook into your own
@@ -111,9 +114,22 @@ public class LottieConfig {
       return this;
     }
 
+    /**
+     * When parsing animations, Lottie has a path interpolator cache. This cache allows Lottie to reuse PathInterpolators
+     * across an animation. This is desirable in most cases. However, when shared across screenshot tests, it can cause slight
+     * deviations in the rendering due to underlying approximations in the PathInterpolator.
+     *
+     * The cache is enabled by default and should probably only be disabled for screenshot tests.
+     */
+    @NonNull
+    public Builder setDisablePathInterpolatorCache(boolean disable) {
+      disablePathInterpolatorCache = disable;
+      return this;
+    }
+
     @NonNull
     public LottieConfig build() {
-      return new LottieConfig(networkFetcher, cacheProvider, enableSystraceMarkers, enableNetworkCache);
+      return new LottieConfig(networkFetcher, cacheProvider, enableSystraceMarkers, enableNetworkCache, disablePathInterpolatorCache);
     }
   }
 }

--- a/snapshot-tests/src/androidTest/java/com/airbnb/lottie/snapshots/LottieSnapshotTest.kt
+++ b/snapshot-tests/src/androidTest/java/com/airbnb/lottie/snapshots/LottieSnapshotTest.kt
@@ -11,7 +11,9 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.rule.GrantPermissionRule
+import com.airbnb.lottie.Lottie
 import com.airbnb.lottie.LottieAnimationView
+import com.airbnb.lottie.LottieConfig
 import com.airbnb.lottie.model.LottieCompositionCache
 import com.airbnb.lottie.snapshots.tests.ApplyOpacityToLayerTestCase
 import com.airbnb.lottie.snapshots.tests.AssetsTestCase
@@ -67,6 +69,11 @@ class LottieSnapshotTest {
     @Before
     fun setup() {
         LottieCompositionCache.getInstance().resize(1)
+        Lottie.initialize(
+            LottieConfig.Builder()
+                .setDisablePathInterpolatorCache(true)
+                .build()
+        )
         val context = ApplicationProvider.getApplicationContext<Context>()
         snapshotter = HappoSnapshotter(context) { name, variant ->
             snapshotActivityRule.scenario.onActivity { activity ->


### PR DESCRIPTION
This should prevent the large diffs in the snapshot tests