### PR TITLE
Check for Application context when comparing contexts for ImageAssetManager

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -1,20 +1,23 @@
 package com.airbnb.lottie.manager;
+
+import android.app.Application;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.view.View;
+
+import androidx.annotation.Nullable;
 
 import com.airbnb.lottie.ImageAssetDelegate;
 import com.airbnb.lottie.LottieImageAsset;
 import com.airbnb.lottie.utils.Logger;
 import com.airbnb.lottie.utils.Utils;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
 
 public class ImageAssetManager {
@@ -134,7 +137,8 @@ public class ImageAssetManager {
   }
 
   public boolean hasSameContext(Context context) {
-    return context == null && this.context == null || this.context.equals(context);
+    Context contextToCompare = this.context instanceof Application ? context.getApplicationContext() : context;
+    return contextToCompare == this.context;
   }
 
   private Bitmap putBitmap(String key, @Nullable Bitmap bitmap) {


### PR DESCRIPTION
I think the root problem for #2281 is that there are 182 720p images played a bitmap sequences. However, while looking into it, I did discover this Context comparison issue. However, the 182 720p images are the real issue for the animation in #2282.