### PR TITLE
Fixes flickering when the same resource is set to the LottieAnimationView

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -112,6 +112,8 @@ import java.util.Set;
 
       if (targetView.fallbackResource != 0) {
         targetView.setImageResource(targetView.fallbackResource);
+      } else {
+        targetView.clearComposition();
       }
       LottieListener<Throwable> l = targetView.failureListener == null ? DEFAULT_FAILURE_LISTENER : targetView.failureListener;
       l.onResult(result);
@@ -588,7 +590,6 @@ import java.util.Set;
 
   private void setCompositionTask(LottieTask<LottieComposition> compositionTask) {
     userActionsTaken.add(UserActionTaken.SET_ANIMATION);
-    clearComposition();
     cancelLoaderTask();
     this.compositionTask = compositionTask
         .addListener(loadedListener)


### PR DESCRIPTION
When the same resource (url, json, etc) is set in a LottieAnimationView multiple times, the view continuously clears and resets the composition resulting in flickering. This change fixes flickering by not eagerly clearing the LottieAnimationView, but instead keeping the old animation displayed until the new composition is available and can be rendered. The view is cleared only when there is a failure loading the new resource.

Fixes #2326