### PR TITLE
[Sample] Handle crash issue after tapping on the Search Tab.

### DIFF
--- a/sample/src/main/kotlin/com/airbnb/lottie/samples/LottiefilesFragment.kt
+++ b/sample/src/main/kotlin/com/airbnb/lottie/samples/LottiefilesFragment.kt
@@ -102,7 +102,10 @@ class LottiefilesDataSource(
     }
 
     override fun getRefreshKey(state: PagingState<Int, AnimationData>): Int? {
-        return state.closestItemToPosition(state.anchorPosition ?: return null)?.id as Int?
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
     }
 }
 


### PR DESCRIPTION
In order to fix the issue, i needed to tweak with the getRefreshKey method which makes sure it returns a valid Int value. Earlier it was throwing a ClassCastException . But now, the method calculates & returns a refresh key based on the current state of paging data. It uses the anchor position to find the closest page, then checks if there is a previous key available. If there is, it increments it by 1. If the previous key is null, it checks if there is a next key available. If there is, it decrements it by 1. The resulting value represents the refresh key or null if both previous and next keys are null.


Before: 
https://github.com/airbnb/lottie-android/assets/8761426/4d24bbcf-44a1-4011-902a-da3b582e437f

After: 
https://github.com/airbnb/lottie-android/assets/8761426/b9efebb6-534c-4b89-a354-f857e662b499
