### PR TITLE
Fix IllegalArgumentException when createBitmap

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -1620,7 +1620,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     int renderWidth = (int) Math.ceil(softwareRenderingTransformedBounds.width());
     int renderHeight = (int) Math.ceil(softwareRenderingTransformedBounds.height());
 
-    if (renderWidth == 0 || renderHeight == 0) {
+    if (renderWidth <= 0 || renderHeight <= 0) {
       return;
     }
 


### PR DESCRIPTION
IllegalArgumentException is thrown when creating bitmap in ensureSoftwareRenderingBitmap() if the getIntrinsicWidth or getIntrinsicHeight returns -1. So, returns when renderWidth or renderHeight is negative to avoid the crash

Fixes https://github.com/airbnb/lottie-android/issues/2350