### PR TITLE
Fix Potential NPE In NetworkCache.clearCache

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkCache.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkCache.java
@@ -37,8 +37,8 @@ public class NetworkCache {
     File parentDir = parentDir();
     if (parentDir.exists()) {
       File[] files = parentDir.listFiles();
-      if (files != null && files.length > 0) {
-        for (File file : parentDir.listFiles()) {
+      if (files != null) {
+        for (File file : files) {
           file.delete();
         }
       }

--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkCache.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkCache.java
@@ -37,7 +37,7 @@ public class NetworkCache {
     File parentDir = parentDir();
     if (parentDir.exists()) {
       File[] files = parentDir.listFiles();
-      if (files != null) {
+      if (files != null && files.length > 0) {
         for (File file : files) {
           file.delete();
         }


### PR DESCRIPTION
In an app that I maintain, a crash was reported in Crashlytics indicating that there was a NPE in the Lottie library code.
![Screenshot 2023-08-18 at 12 45 55 PM](https://github.com/airbnb/lottie-android/assets/31358071/a3a50f1f-d05a-4cb2-bb77-20a49702fda7)

It took me a bit to realize why the NPE was being caused by trying to read the length of a null array, but then I realized, the for loop calls `parentDir.listFiles()` again to iterate over rather than using the `files` array that was just checked the line above.

The changes are quite minor and should fix the problem of the NPE, that being said there may be other concerns that I'm not aware of.