### PR TITLE
Fix a NPE in ColorKeyframeAnimation

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/ColorKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/ColorKeyframeAnimation.java
@@ -25,7 +25,10 @@ public class ColorKeyframeAnimation extends KeyframeAnimation<Integer> {
       throw new IllegalStateException("Missing values for keyframe.");
     }
 
-    if (valueCallback != null) {
+    // keyframe.endFrame should not be null under normal operation.
+    // It is not clear why this would be null and when it does, it seems to be extremely rare.
+    // https://github.com/airbnb/lottie-android/issues/2361
+    if (valueCallback != null && keyframe.endFrame != null) {
       //noinspection ConstantConditions
       Integer value = valueCallback.getValueInternal(keyframe.startFrame, keyframe.endFrame, keyframe.startValue,
           keyframe.endValue, keyframeProgress, getLinearCurrentKeyframeProgress(), getProgress());


### PR DESCRIPTION
It is not clear to me why or how this would happen. endFrame is technically nullable because of the order that parsing happens but it should be non-null by the time parsing finishes. This should be safe enough to add to fix this NPE though.

Fixes #2361 