### PR TITLE
Add ability to load dotLottie via LottieAnimationView

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.zip.ZipInputStream;
 
 /**
  * This view will load, deserialize, and display an After Effects animation exported with
@@ -553,6 +554,12 @@ import java.util.Set;
    */
   public void setAnimationFromUrl(String url, @Nullable String cacheKey) {
     LottieTask<LottieComposition> task = LottieCompositionFactory.fromUrl(getContext(), url, cacheKey);
+    setCompositionTask(task);
+  }
+
+  public void setAnimationFromDotLottie(ZipInputStream stream, @Nullable String cacheKey) {
+    LottieTask<LottieComposition> task = cacheComposition ?
+        LottieCompositionFactory.fromZipStream(stream, cacheKey) : LottieCompositionFactory.fromZipStream(stream, null);
     setCompositionTask(task);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -559,7 +559,7 @@ import java.util.zip.ZipInputStream;
 
   public void setAnimationFromDotLottie(ZipInputStream stream, @Nullable String cacheKey) {
     LottieTask<LottieComposition> task = cacheComposition ?
-        LottieCompositionFactory.fromZipStream(stream, cacheKey) : LottieCompositionFactory.fromZipStream(stream, null);
+        LottieCompositionFactory.fromZipStream(getContext(), stream, cacheKey) : LottieCompositionFactory.fromZipStream(getContext(), stream, null);
     setCompositionTask(task);
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -557,6 +557,11 @@ import java.util.zip.ZipInputStream;
     setCompositionTask(task);
   }
 
+  /**
+   * Load a <a href="https://dotlottie.io/">dotLottie</a> animation from a ZipInputStream.
+   * <p>
+   * Auto-closes the stream.
+   */
   public void setAnimationFromDotLottie(ZipInputStream stream, @Nullable String cacheKey) {
     LottieTask<LottieComposition> task = cacheComposition ?
         LottieCompositionFactory.fromZipStream(getContext(), stream, cacheKey) : LottieCompositionFactory.fromZipStream(getContext(), stream, null);

--- a/sample/src/main/kotlin/com/airbnb/lottie/samples/PreviewFragment.kt
+++ b/sample/src/main/kotlin/com/airbnb/lottie/samples/PreviewFragment.kt
@@ -52,7 +52,7 @@ class PreviewFragment : BaseEpoxyFragment() {
                         addCategory(Intent.CATEGORY_OPENABLE)
                     }
                     @Suppress("DEPRECATION")
-                    startActivityForResult(Intent.createChooser(intent, "Select a JSON file"), RC_FILE)
+                    startActivityForResult(Intent.createChooser(intent, "Select a JSON, ZIP, or dotLottie file"), RC_FILE)
                 } catch (ex: ActivityNotFoundException) {
                     // Potentially direct the user to the Market with a Dialog
                     Toast.makeText(context, "Please install a File Manager.", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
Relevant issue: https://github.com/airbnb/lottie-android/issues/2409

Adds a `setAnimationFromDotLottie()` method to `LottieAnimationView` that accepts a `ZipInputStream`.