### PR TITLE
Add support for gzipped and tgs files from network

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/network/FileExtension.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/FileExtension.java
@@ -8,7 +8,8 @@ import androidx.annotation.RestrictTo;
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public enum FileExtension {
   JSON(".json"),
-  ZIP(".zip");
+  ZIP(".zip"),
+  GZIP(".gz");
 
   public final String extension;
 

--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkCache.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkCache.java
@@ -76,6 +76,8 @@ public class NetworkCache {
     FileExtension extension;
     if (cachedFile.getAbsolutePath().endsWith(".zip")) {
       extension = FileExtension.ZIP;
+    } else if (cachedFile.getAbsolutePath().endsWith(".gz")) {
+      extension = FileExtension.GZIP;
     } else {
       extension = FileExtension.JSON;
     }
@@ -142,6 +144,10 @@ public class NetworkCache {
     File zipFile = new File(parentDir(), filenameForUrl(url, FileExtension.ZIP, false));
     if (zipFile.exists()) {
       return zipFile;
+    }
+    File gzipFile = new File(parentDir(), filenameForUrl(url, FileExtension.GZIP, false));
+    if (gzipFile.exists()) {
+      return gzipFile;
     }
     return null;
   }


### PR DESCRIPTION
In addition to [#2435](https://github.com/airbnb/lottie-android/pull/2435), added support for loading gziped and tgs files from the network, similar to zip files.