### PR TITLE
Call LottieTask listeners synchronously when already on the main thread

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieTask.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieTask.java
@@ -137,18 +137,24 @@ public class LottieTask<T> {
 
   private void notifyListeners() {
     // Listeners should be called on the main thread.
-    handler.post(() -> {
-      // Local reference in case it gets set on a background thread.
-      LottieResult<T> result = LottieTask.this.result;
-      if (result == null) {
-        return;
-      }
-      if (result.getValue() != null) {
-        notifySuccessListeners(result.getValue());
-      } else {
-        notifyFailureListeners(result.getException());
-      }
-    });
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      notifyListenersInternal();
+    } else {
+      handler.post(this::notifyListenersInternal);
+    }
+  }
+
+  private void notifyListenersInternal() {
+    // Local reference in case it gets set on a background thread.
+    LottieResult<T> result = LottieTask.this.result;
+    if (result == null) {
+      return;
+    }
+    if (result.getValue() != null) {
+      notifySuccessListeners(result.getValue());
+    } else {
+      notifyFailureListeners(result.getException());
+    }
   }
 
   private synchronized void notifySuccessListeners(T value) {


### PR DESCRIPTION
When we are already on the main thread, there is no need to post listeners to the main thread again.

As a side effect, this fixes https://github.com/airbnb/lottie-android/issues/2449. The listener was called twice because it was called synchronously in addListener because it was already done and then because of the post, it was called again.

Fixes https://github.com/airbnb/lottie-android/issues/2449