### PR TITLE
Fix image scaling when the display scale changes

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieComposition.java
@@ -219,13 +219,13 @@ public class LottieComposition {
   public Map<String, LottieImageAsset> getImages() {
     float dpScale = Utils.dpScale();
     if (dpScale != imagesDpScale) {
-      imagesDpScale = dpScale;
       Set<Map.Entry<String, LottieImageAsset>> entries = images.entrySet();
 
       for (Map.Entry<String, LottieImageAsset> entry : entries) {
         images.put(entry.getKey(), entry.getValue().copyWithScale(imagesDpScale / dpScale));
       }
     }
+    imagesDpScale = dpScale;
     return images;
   }
 


### PR DESCRIPTION
This was a simple logic bug that made the scale always 1.0

Fixes https://github.com/airbnb/lottie-android/issues/2216