### PR TITLE
Fix base64 image asset not fit container's size

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -640,7 +640,9 @@ public class LottieCompositionFactory {
             Logger.warning("data URL did not have correct base64 format.", e);
             return null;
           }
-          asset.setBitmap(BitmapFactory.decodeByteArray(data, 0, data.length, opts));
+          Bitmap bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, opts);
+          bitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
+          asset.setBitmap(bitmap);
         }
       }
     }

--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -107,7 +107,8 @@ public class ImageAssetManager {
         return null;
       }
       bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, opts);
-      return putBitmap(id, bitmap);
+      Bitmap resizedBitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
+      return putBitmap(id, resizedBitmap);
     }
 
     InputStream is;


### PR DESCRIPTION
Currently, I am encountering a similar issue to [#1200](https://github.com/airbnb/lottie-android/issues/1200), but in the case where the asset is a base64 image, it has not been fixed yet.