### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lottie for Android, [iOS](https://github.com/airbnb/lottie-ios), [React Native](https://github.com/airbnb/lottie-react-native), [Web](https://github.com/airbnb/lottie-web), and [Windows](https://aka.ms/lottie)
 
-![Build Status](https://github.com/airbnb/lottie-android/workflows/Verify/badge.svg)
+![Build Status](https://github.com/airbnb/lottie-android/workflows/Validate/badge.svg)
 
 <a href='https://play.google.com/store/apps/details?id=com.airbnb.lottie'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="50px"/></a>
 


### PR DESCRIPTION
`Verify` (404) -> `Validate` (![](https://github.com/airbnb/lottie-android/workflows/Validate/badge.svg))