### PR TITLE
Fix value callback is not called for PathKeyframeAnimation

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/PathKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/PathKeyframeAnimation.java
@@ -20,14 +20,10 @@ public class PathKeyframeAnimation extends KeyframeAnimation<PointF> {
   }
 
   @Override public PointF getValue(Keyframe<PointF> keyframe, float keyframeProgress) {
-    if (keyframe.startValue == null || keyframe.endValue == null) {
-      throw new IllegalStateException("Missing values for keyframe.");
-    }
-
     PathKeyframe pathKeyframe = (PathKeyframe) keyframe;
     Path path = pathKeyframe.getPath();
 
-    if (valueCallback != null) {
+    if (valueCallback != null && keyframe.endFrame != null) {
       PointF value = valueCallback.getValueInternal(pathKeyframe.startFrame, pathKeyframe.endFrame,
           pathKeyframe.startValue, pathKeyframe.endValue, getLinearCurrentKeyframeProgress(),
           keyframeProgress, getProgress());

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/PathKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/PathKeyframeAnimation.java
@@ -20,11 +20,12 @@ public class PathKeyframeAnimation extends KeyframeAnimation<PointF> {
   }
 
   @Override public PointF getValue(Keyframe<PointF> keyframe, float keyframeProgress) {
+    if (keyframe.startValue == null || keyframe.endValue == null) {
+      throw new IllegalStateException("Missing values for keyframe.");
+    }
+
     PathKeyframe pathKeyframe = (PathKeyframe) keyframe;
     Path path = pathKeyframe.getPath();
-    if (path == null) {
-      return keyframe.startValue;
-    }
 
     if (valueCallback != null) {
       PointF value = valueCallback.getValueInternal(pathKeyframe.startFrame, pathKeyframe.endFrame,
@@ -33,6 +34,10 @@ public class PathKeyframeAnimation extends KeyframeAnimation<PointF> {
       if (value != null) {
         return value;
       }
+    }
+
+    if (path == null) {
+      return keyframe.startValue;
     }
 
     if (pathMeasureKeyframe != pathKeyframe) {


### PR DESCRIPTION
A value callback was not called, when only single value is defined for keyframe in PathKeyframeAnimation.

This PR also adds the check for startValue and endValue at start, same way it is done for other types of KeyframeAnimation.