### PR TITLE
[a11y] Adding reduce motion logic to LottieAnimation for compose usage

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
@@ -133,8 +133,9 @@ fun LottieAnimation(
             drawable.maintainOriginalImageBounds = maintainOriginalImageBounds
             drawable.clipToCompositionBounds = clipToCompositionBounds
             drawable.clipTextToBoundingBox = clipTextToBoundingBox
-            if (!drawable.animationsEnabled(context) && drawable.markerForAnimationsDisabled != null) {
-                drawable.progress = drawable.markerForAnimationsDisabled!!.startFrame
+            val markerForAnimationsDisabled = drawable.markerForAnimationsDisabled
+            if (!drawable.animationsEnabled(context) && markerForAnimationsDisabled != null) {
+                drawable.progress = markerForAnimationsDisabled.startFrame
             } else {
                 drawable.progress = progress()
             }

--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.ScaleFactor
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntSize
 import com.airbnb.lottie.AsyncUpdates
 import com.airbnb.lottie.LottieComposition
@@ -101,6 +102,7 @@ fun LottieAnimation(
     if (composition == null || composition.duration == 0f) return Box(modifier)
 
     val bounds = composition.bounds
+    val context = LocalContext.current
     Canvas(
         modifier = modifier
             .lottieSize(bounds.width(), bounds.height())
@@ -131,7 +133,11 @@ fun LottieAnimation(
             drawable.maintainOriginalImageBounds = maintainOriginalImageBounds
             drawable.clipToCompositionBounds = clipToCompositionBounds
             drawable.clipTextToBoundingBox = clipTextToBoundingBox
-            drawable.progress = progress()
+            if (!drawable.animationsEnabled(context) && drawable.markerForAnimationsDisabled != null) {
+                drawable.progress = drawable.markerForAnimationsDisabled!!.startFrame
+            } else {
+                drawable.progress = progress()
+            }
             drawable.setBounds(0, 0, bounds.width(), bounds.height())
             drawable.draw(canvas.nativeCanvas, matrix)
         }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -823,7 +823,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     }
 
     computeRenderMode();
-    if (animationsEnabled() || getRepeatCount() == 0) {
+    if (animationsEnabled(getContext()) || getRepeatCount() == 0) {
       if (isVisible()) {
         animator.playAnimation();
         onVisibleAction = OnVisibleAction.NONE;
@@ -831,7 +831,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
         onVisibleAction = OnVisibleAction.PLAY;
       }
     }
-    if (!animationsEnabled()) {
+    if (!animationsEnabled(getContext())) {
       Marker markerForAnimationsDisabled = getMarkerForAnimationsDisabled();
       if (markerForAnimationsDisabled != null) {
         setFrame((int) markerForAnimationsDisabled.startFrame);
@@ -853,7 +853,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    *
    * @return The first non-null marker from the list of allowed reduced motion markers, or null if no such marker is found.
    */
-  private Marker getMarkerForAnimationsDisabled() {
+  public Marker getMarkerForAnimationsDisabled() {
     Marker marker = null;
     for (String markerName : ALLOWED_REDUCED_MOTION_MARKERS) {
       marker = composition.getMarker(markerName);
@@ -885,7 +885,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     }
 
     computeRenderMode();
-    if (animationsEnabled() || getRepeatCount() == 0) {
+    if (animationsEnabled(getContext()) || getRepeatCount() == 0) {
       if (isVisible()) {
         animator.resumeAnimation();
         onVisibleAction = OnVisibleAction.NONE;
@@ -893,7 +893,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
         onVisibleAction = OnVisibleAction.RESUME;
       }
     }
-    if (!animationsEnabled()) {
+    if (!animationsEnabled(getContext())) {
       setFrame((int) (getSpeed() < 0 ? getMinFrame() : getMaxFrame()));
       animator.endAnimation();
       if (!isVisible()) {
@@ -1244,12 +1244,12 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     }
   }
 
-  private boolean animationsEnabled() {
+  public boolean animationsEnabled(Context context) {
     if (ignoreSystemAnimationsDisabled) {
       return true;
     }
     return systemAnimationsEnabled &&
-        L.getReducedMotionOption().getCurrentReducedMotionMode(getContext()) == ReducedMotionMode.STANDARD_MOTION;
+        L.getReducedMotionOption().getCurrentReducedMotionMode(context) == ReducedMotionMode.STANDARD_MOTION;
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -853,6 +853,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
    *
    * @return The first non-null marker from the list of allowed reduced motion markers, or null if no such marker is found.
    */
+  @RestrictTo(RestrictTo.Scope.LIBRARY)
   public Marker getMarkerForAnimationsDisabled() {
     Marker marker = null;
     for (String markerName : ALLOWED_REDUCED_MOTION_MARKERS) {


### PR DESCRIPTION
Our changes in https://github.com/airbnb/lottie-android/pull/2536 didn't work for `LottieAnimation` in compose. While LottieAnimation does use LottieDrawable, it has it's own animator and draws on canvas directly. 

This PR addresses that issue by making some logic of reduce motion readable outside LottieDrawable and consuming that logic in `LottieAnimation` 

I tested this by adding a sample lottie file with reduce motion marker locally, see the attached video. 

https://github.com/user-attachments/assets/eb33333f-86b8-46fa-9bbb-82bff8a8c7fe


