### PR TITLE
Fix SplitDimensionPathKeyframeAnimation value callbacks arguments

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/SplitDimensionPathKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/SplitDimensionPathKeyframeAnimation.java
@@ -70,21 +70,29 @@ public class SplitDimensionPathKeyframeAnimation extends BaseKeyframeAnimation<P
     if (xValueCallback != null) {
       Keyframe<Float> xKeyframe = xAnimation.getCurrentKeyframe();
       if (xKeyframe != null) {
-        float progress = xAnimation.getInterpolatedCurrentKeyframeProgress();
         Float endFrame = xKeyframe.endFrame;
         xCallbackValue =
-            xValueCallback.getValueInternal(xKeyframe.startFrame, endFrame == null ? xKeyframe.startFrame : endFrame, xKeyframe.startValue,
-                xKeyframe.endValue, keyframeProgress, keyframeProgress, progress);
+            xValueCallback.getValueInternal(xKeyframe.startFrame,
+                endFrame == null ? xKeyframe.startFrame : endFrame,
+                xKeyframe.startValue,
+                xKeyframe.endValue,
+                xAnimation.getInterpolatedCurrentKeyframeProgress(),
+                xAnimation.getLinearCurrentKeyframeProgress(),
+                xAnimation.getProgress());
       }
     }
     if (yValueCallback != null) {
       Keyframe<Float> yKeyframe = yAnimation.getCurrentKeyframe();
       if (yKeyframe != null) {
-        float progress = yAnimation.getInterpolatedCurrentKeyframeProgress();
         Float endFrame = yKeyframe.endFrame;
         yCallbackValue =
-            yValueCallback.getValueInternal(yKeyframe.startFrame, endFrame == null ? yKeyframe.startFrame : endFrame, yKeyframe.startValue,
-                yKeyframe.endValue, keyframeProgress, keyframeProgress, progress);
+            yValueCallback.getValueInternal(yKeyframe.startFrame,
+                endFrame == null ? yKeyframe.startFrame : endFrame,
+                yKeyframe.startValue,
+                yKeyframe.endValue,
+                yAnimation.getInterpolatedCurrentKeyframeProgress(),
+                yAnimation.getLinearCurrentKeyframeProgress(),
+                yAnimation.getProgress());
       }
     }
 


### PR DESCRIPTION
Use proper values for keyframe progress for value callbacks instead of the keyframeProgress from function arguments which is always zero.