### PR TITLE
Fix resolving key path for matte layers

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -746,7 +746,7 @@ public abstract class BaseLayer
         accumulator.add(matteCurrentPartialKeyPath.resolve(matteLayer));
       }
 
-      if (keyPath.propagateToChildren(getName(), depth)) {
+      if (keyPath.matches(matteLayer.getName(), depth) && keyPath.propagateToChildren(getName(), depth)) {
         int newDepth = depth + keyPath.incrementDepthBy(matteLayer.getName(), depth);
         matteLayer.resolveChildKeyPath(keyPath, newDepth, accumulator, matteCurrentPartialKeyPath);
       }


### PR DESCRIPTION
This PR adds the check for matte layer name before going deeper during key path resolution.

Without the fix the key path matches children inside the matte layer even though it should not, for example:

'layer_1.group_1.child_1' could match 'layer_1.**matte_1**.group_1.child_1'

With the fix it is not possible anymore.