### PR TITLE
Adding null check for context before calling `Utils.getAnimationScale`

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -1245,7 +1245,7 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
     }
   }
 
-  public boolean animationsEnabled(Context context) {
+  public boolean animationsEnabled(@Nullable Context context) {
     if (ignoreSystemAnimationsDisabled) {
       return true;
     }

--- a/lottie/src/main/java/com/airbnb/lottie/configurations/reducemotion/ReducedMotionOption.java
+++ b/lottie/src/main/java/com/airbnb/lottie/configurations/reducemotion/ReducedMotionOption.java
@@ -1,11 +1,12 @@
 package com.airbnb.lottie.configurations.reducemotion;
 
 import android.content.Context;
+import androidx.annotation.Nullable;
 
 public interface ReducedMotionOption {
 
   /**
    * Returns the current reduced motion mode.
    */
-  ReducedMotionMode getCurrentReducedMotionMode(Context context);
+  ReducedMotionMode getCurrentReducedMotionMode(@Nullable Context context);
 }

--- a/lottie/src/main/java/com/airbnb/lottie/configurations/reducemotion/SystemReducedMotionOption.java
+++ b/lottie/src/main/java/com/airbnb/lottie/configurations/reducemotion/SystemReducedMotionOption.java
@@ -1,6 +1,7 @@
 package com.airbnb.lottie.configurations.reducemotion;
 
 import android.content.Context;
+import androidx.annotation.Nullable;
 import com.airbnb.lottie.utils.Utils;
 
 /**
@@ -18,8 +19,8 @@ import com.airbnb.lottie.utils.Utils;
 public class SystemReducedMotionOption implements ReducedMotionOption {
 
   @Override
-  public ReducedMotionMode getCurrentReducedMotionMode(Context context) {
-    if (Utils.getAnimationScale(context) != 0f) {
+  public ReducedMotionMode getCurrentReducedMotionMode(@Nullable Context context) {
+    if (context == null || Utils.getAnimationScale(context) != 0f) {
       return ReducedMotionMode.STANDARD_MOTION;
     } else {
       return ReducedMotionMode.REDUCED_MOTION;

--- a/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
@@ -14,6 +14,7 @@ import android.graphics.RectF;
 import android.os.Build;
 import android.provider.Settings;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.airbnb.lottie.L;
@@ -262,7 +263,7 @@ public final class Utils {
     return Resources.getSystem().getDisplayMetrics().density;
   }
 
-  public static float getAnimationScale(Context context) {
+  public static float getAnimationScale(@NonNull Context context) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
       return Settings.Global.getFloat(context.getContentResolver(),
           Settings.Global.ANIMATOR_DURATION_SCALE, 1.0f);


### PR DESCRIPTION
When calling reduce motion check we need to pass context, we read context in LottieDrawable using `getContext` method. getContext method can return a nullable context, since the code is in java we don't get any compile time error when passing the null context around. 

This resulted in issue where we end up calling `getContentResolver` on a null object in case where context is null. https://github.com/airbnb/lottie-android/pull/2536

This PR fixes it by adding a null check before calling `Utils.getAnimationScale(context)`