### PR TITLE
Improve blur effect accuracy

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/LottieAnimation.kt
@@ -49,6 +49,11 @@ import kotlin.math.roundToInt
  *                             expense of performance.
  *                             Note: This process is very expensive. The performance impact will be reduced
  *                             when hardware acceleration is enabled.
+ * @param applyEffectsToLayers Sets whether to apply effects such as drop shadow and blur to each layer instead of
+ *                             individually per shape. In case where effects are applied to shape groups and
+ *                             composition layers, this will improve correctness but at a performance cost.
+ *                             Note: This process is expensive when hardware acceleration is unavailable.
+ * @param applyShadowToLayers  Equivalent to applyEffectsToLayers, but exposed for backwards compatibility.
  * @param enableMergePaths Enables experimental merge paths support. Most animations with merge paths will
  *                         want this on but merge path support is more limited than some other rendering
  *                         features so it defaults to off. The only way to know if your animation will work
@@ -83,7 +88,8 @@ fun LottieAnimation(
     modifier: Modifier = Modifier,
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
-    applyShadowToLayers: Boolean = true,
+    applyShadowToLayers: Boolean? = null,
+    applyEffectsToLayers: Boolean = true,
     enableMergePaths: Boolean = false,
     renderMode: RenderMode = RenderMode.AUTOMATIC,
     maintainOriginalImageBounds: Boolean = false,
@@ -131,7 +137,10 @@ fun LottieAnimation(
             }
             drawable.setOutlineMasksAndMattes(outlineMasksAndMattes)
             drawable.isApplyingOpacityToLayersEnabled = applyOpacityToLayers
-            drawable.isApplyingShadowToLayersEnabled = applyShadowToLayers
+            drawable.isApplyingEffectsToLayersEnabled = applyEffectsToLayers
+            if (applyShadowToLayers != null) {
+                drawable.isApplyingEffectsToLayersEnabled = applyShadowToLayers;
+            }
             drawable.maintainOriginalImageBounds = maintainOriginalImageBounds
             drawable.clipToCompositionBounds = clipToCompositionBounds
             drawable.clipTextToBoundingBox = clipTextToBoundingBox
@@ -160,7 +169,7 @@ fun LottieAnimation(
     modifier: Modifier = Modifier,
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
-    applyShadowToLayers: Boolean = true,
+    applyEffectsToLayers: Boolean = true,
     enableMergePaths: Boolean = false,
     renderMode: RenderMode = RenderMode.AUTOMATIC,
     maintainOriginalImageBounds: Boolean = false,
@@ -177,7 +186,7 @@ fun LottieAnimation(
         modifier = modifier,
         outlineMasksAndMattes = outlineMasksAndMattes,
         applyOpacityToLayers = applyOpacityToLayers,
-        applyShadowToLayers = applyShadowToLayers,
+        applyEffectsToLayers = applyEffectsToLayers,
         enableMergePaths = enableMergePaths,
         renderMode = renderMode,
         maintainOriginalImageBounds = maintainOriginalImageBounds,
@@ -209,7 +218,7 @@ fun LottieAnimation(
     iterations: Int = 1,
     outlineMasksAndMattes: Boolean = false,
     applyOpacityToLayers: Boolean = false,
-    applyShadowToLayers: Boolean = true,
+    applyEffectsToLayers: Boolean = true,
     enableMergePaths: Boolean = false,
     renderMode: RenderMode = RenderMode.AUTOMATIC,
     reverseOnRepeat: Boolean = false,
@@ -238,7 +247,7 @@ fun LottieAnimation(
         modifier = modifier,
         outlineMasksAndMattes = outlineMasksAndMattes,
         applyOpacityToLayers = applyOpacityToLayers,
-        applyShadowToLayers = applyShadowToLayers,
+        applyEffectsToLayers = applyEffectsToLayers,
         enableMergePaths = enableMergePaths,
         renderMode = renderMode,
         maintainOriginalImageBounds = maintainOriginalImageBounds,

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -225,8 +225,14 @@ import java.util.zip.ZipInputStream;
         R.styleable.LottieAnimationView_lottie_enableMergePathsForKitKatAndAbove, false));
     setApplyingOpacityToLayersEnabled(ta.getBoolean(
         R.styleable.LottieAnimationView_lottie_applyOpacityToLayers, false));
-    setApplyingShadowToLayersEnabled(ta.getBoolean(
-        R.styleable.LottieAnimationView_lottie_applyShadowToLayers, true));
+    setApplyingEffectsToLayersEnabled(ta.getBoolean(
+        R.styleable.LottieAnimationView_lottie_applyEffectsToLayers, true));
+
+    // Respect the old applyShadowsToLayers if provided
+    if (ta.hasValue(R.styleable.LottieAnimationView_lottie_applyShadowToLayers)) {
+      setApplyingEffectsToLayersEnabled(ta.getBoolean(
+          R.styleable.LottieAnimationView_lottie_applyShadowToLayers, true));
+    }
 
     if (ta.hasValue(R.styleable.LottieAnimationView_lottie_colorFilter)) {
       int colorRes = ta.getResourceId(R.styleable.LottieAnimationView_lottie_colorFilter, -1);
@@ -1266,10 +1272,19 @@ import java.util.zip.ZipInputStream;
    *
    * @see LottieAnimationView::setApplyingOpacityToLayersEnabled
    */
-  public void setApplyingShadowToLayersEnabled(boolean isApplyingShadowToLayersEnabled) {
-    lottieDrawable.setApplyingShadowToLayersEnabled(isApplyingShadowToLayersEnabled);
+  public void setApplyingEffectsToLayersEnabled(boolean isApplyingEffectsToLayersEnabled) {
+    lottieDrawable.setApplyingEffectsToLayersEnabled(isApplyingEffectsToLayersEnabled);
   }
 
+  /**
+   * This has been renamed to setApplyingEffectsToLayersEnabled. Prefer using that instead.
+   *
+   * @see LottieAnimationView::setApplyingEffectsToLayersEnabled
+   */
+  @Deprecated
+  public void setApplyingShadowToLayersEnabled(boolean isApplyingShadowsToLayersEnabled) {
+    lottieDrawable.setApplyingEffectsToLayersEnabled(isApplyingShadowsToLayersEnabled);
+  }
   /**
    * @see #setClipTextToBoundingBox(boolean)
    */

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/ContentGroup.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/ContentGroup.java
@@ -160,7 +160,7 @@ public class ContentGroup implements DrawingContent, PathContent,
     return path;
   }
 
-  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply) {
+  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply, float blurToApply) {
     if (hidden) {
       return;
     }
@@ -177,7 +177,7 @@ public class ContentGroup implements DrawingContent, PathContent,
     // Apply off-screen rendering only when needed in order to improve rendering performance.
     boolean isRenderingWithOffScreen =
         (lottieDrawable.isApplyingOpacityToLayersEnabled() && hasTwoOrMoreDrawableContent() && layerAlpha != 255) ||
-        (shadowToApply != null && lottieDrawable.isApplyingShadowToLayersEnabled() && hasTwoOrMoreDrawableContent());
+        ((shadowToApply != null || blurToApply > 0.0f) && lottieDrawable.isApplyingEffectsToLayersEnabled() && hasTwoOrMoreDrawableContent());
     int childAlpha = isRenderingWithOffScreen ? 255 : layerAlpha;
 
     Canvas contentCanvas = canvas;
@@ -187,7 +187,10 @@ public class ContentGroup implements DrawingContent, PathContent,
       offscreenOp.alpha = layerAlpha;
       if (shadowToApply != null) {
         shadowToApply.applyTo(offscreenOp);
-        shadowToApply = null; // Don't pass it to children - OffscreenLayer now takes care of this
+
+        // Don't pass effects to children - OffscreenLayer now takes care of this
+        shadowToApply = null;
+        blurToApply = 0.0f;
       } else {
         offscreenOp.shadow = null;
       }
@@ -203,7 +206,7 @@ public class ContentGroup implements DrawingContent, PathContent,
     for (int i = contents.size() - 1; i >= 0; i--) {
       Object content = contents.get(i);
       if (content instanceof DrawingContent) {
-        ((DrawingContent) content).draw(contentCanvas, matrix, childAlpha, shadowToApply);
+        ((DrawingContent) content).draw(contentCanvas, matrix, childAlpha, shadowToApply, blurToApply);
       }
     }
 

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/DrawingContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/DrawingContent.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 import com.airbnb.lottie.utils.DropShadow;
 
 public interface DrawingContent extends Content {
-  void draw(Canvas canvas, Matrix parentMatrix, int alpha, @Nullable DropShadow shadowToApply);
+  void draw(Canvas canvas, Matrix parentMatrix, int alpha, @Nullable DropShadow shadowToApply, float blurToApply);
 
   void getBounds(RectF outBounds, Matrix parentMatrix, boolean applyParents);
 }

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/FillContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/FillContent.java
@@ -89,7 +89,7 @@ public class FillContent
     return name;
   }
 
-  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply) {
+  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply, float blurToApply) {
     if (hidden) {
       return;
     }
@@ -106,16 +106,15 @@ public class FillContent
       paint.setColorFilter(colorFilterAnimation.getValue());
     }
 
-    if (blurAnimation != null) {
-      float blurRadius = blurAnimation.getValue();
-      if (blurRadius == 0f) {
-        paint.setMaskFilter(null);
-      } else if (blurRadius != blurMaskFilterRadius) {
-        BlurMaskFilter blur = layer.getBlurMaskFilter(blurRadius);
-        paint.setMaskFilter(blur);
-      }
-      blurMaskFilterRadius = blurRadius;
+
+    if (blurToApply == 0f) {
+      paint.setMaskFilter(null);
+    } else if (blurToApply != blurMaskFilterRadius) {
+      BlurMaskFilter blur = layer.getBlurMaskFilter(blurToApply);
+      paint.setMaskFilter(blur);
     }
+    blurMaskFilterRadius = blurToApply;
+
     if (shadowToApply != null) {
       shadowToApply.applyWithAlpha((int)(fillAlpha * 255), paint);
     } else {

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/GradientFillContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/GradientFillContent.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 public class GradientFillContent
     implements DrawingContent, BaseKeyframeAnimation.AnimationListener, KeyPathElementContent {
+
   /**
    * Cache the gradients such that it runs at 30fps.
    */
@@ -109,7 +110,7 @@ public class GradientFillContent
     }
   }
 
-  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply) {
+  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply, float blurToApply) {
     if (hidden) {
       return;
     }
@@ -136,15 +137,14 @@ public class GradientFillContent
       paint.setColorFilter(colorFilterAnimation.getValue());
     }
 
-    if (blurAnimation != null) {
-      float blurRadius = blurAnimation.getValue();
-      if (blurRadius == 0f) {
-        paint.setMaskFilter(null);
-      } else if (blurRadius != blurMaskFilterRadius){
-        BlurMaskFilter blur = new BlurMaskFilter(blurRadius, BlurMaskFilter.Blur.NORMAL);
+    if (blurToApply != blurMaskFilterRadius) {
+      if (blurToApply > 0.0f) {
+        BlurMaskFilter blur = new BlurMaskFilter(blurToApply, BlurMaskFilter.Blur.NORMAL);
         paint.setMaskFilter(blur);
+      } else {
+        paint.setMaskFilter(null);
       }
-      blurMaskFilterRadius = blurRadius;
+      blurMaskFilterRadius = blurToApply;
     }
 
     float fillAlpha = opacityAnimation.getValue() / 100f;
@@ -153,7 +153,7 @@ public class GradientFillContent
     paint.setAlpha(alpha);
 
     if (shadowToApply != null) {
-      shadowToApply.applyWithAlpha((int)(fillAlpha * 255), paint);
+      shadowToApply.applyWithAlpha((int) (fillAlpha * 255), paint);
     }
 
     canvas.drawPath(path, paint);

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/GradientStrokeContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/GradientStrokeContent.java
@@ -65,7 +65,7 @@ public class GradientStrokeContent extends BaseStrokeContent {
     layer.addAnimation(endPointAnimation);
   }
 
-  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, DropShadow shadowToApply) {
+  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, DropShadow shadowToApply, float blurToApply) {
     if (hidden) {
       return;
     }
@@ -79,7 +79,7 @@ public class GradientStrokeContent extends BaseStrokeContent {
     }
     paint.setShader(shader);
 
-    super.draw(canvas, parentMatrix, parentAlpha, shadowToApply);
+    super.draw(canvas, parentMatrix, parentAlpha, shadowToApply, blurToApply);
   }
 
   @Override public String getName() {

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/RepeaterContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/RepeaterContent.java
@@ -106,7 +106,7 @@ public class RepeaterContent implements DrawingContent, PathContent, GreedyConte
     return path;
   }
 
-  @Override public void draw(Canvas canvas, Matrix parentMatrix, int alpha, @Nullable DropShadow shadowToApply) {
+  @Override public void draw(Canvas canvas, Matrix parentMatrix, int alpha, @Nullable DropShadow shadowToApply, float blurToApply) {
     float copies = this.copies.getValue();
     float offset = this.offset.getValue();
     //noinspection ConstantConditions
@@ -117,9 +117,9 @@ public class RepeaterContent implements DrawingContent, PathContent, GreedyConte
       matrix.set(parentMatrix);
       matrix.preConcat(transform.getMatrixForRepeater(i + offset));
       float newAlpha = alpha * MiscUtils.lerp(startOpacity, endOpacity, i / copies);
-      // A repeater renders its contents as if by simple re-rendering, so it should be fine to pass shadowToApply
-      // here, even when we have more than 1 copy.
-      contentGroup.draw(canvas, matrix, (int) newAlpha, shadowToApply);
+      // A repeater renders its contents as if by simple re-rendering, so it should be fine to pass shadowToApply and
+      // blurToApply here, even when we have more than 1 copy.
+      contentGroup.draw(canvas, matrix, (int) newAlpha, shadowToApply, blurToApply);
     }
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/animation/content/StrokeContent.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/content/StrokeContent.java
@@ -38,7 +38,7 @@ public class StrokeContent extends BaseStrokeContent {
     layer.addAnimation(colorAnimation);
   }
 
-  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply) {
+  @Override public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply, float blurToApply) {
     if (hidden) {
       return;
     }
@@ -46,7 +46,7 @@ public class StrokeContent extends BaseStrokeContent {
     if (colorFilterAnimation != null) {
       paint.setColorFilter(colorFilterAnimation.getValue());
     }
-    super.draw(canvas, parentMatrix, parentAlpha, shadowToApply);
+    super.draw(canvas, parentMatrix, parentAlpha, shadowToApply, blurToApply);
   }
 
   @Override public String getName() {

--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/BlurKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/BlurKeyframeAnimation.java
@@ -1,0 +1,49 @@
+package com.airbnb.lottie.animation.keyframe;
+
+import android.graphics.Color;
+import android.graphics.Matrix;
+import androidx.annotation.Nullable;
+import com.airbnb.lottie.model.content.BlurEffect;
+import com.airbnb.lottie.model.layer.BaseLayer;
+import com.airbnb.lottie.value.LottieValueCallback;
+
+
+public class BlurKeyframeAnimation implements BaseKeyframeAnimation.AnimationListener {
+  private final BaseLayer layer;
+  private final BaseKeyframeAnimation.AnimationListener listener;
+  private final FloatKeyframeAnimation blurriness;
+
+  public BlurKeyframeAnimation(BaseKeyframeAnimation.AnimationListener listener, BaseLayer layer, BlurEffect blurEffect) {
+    this.listener = listener;
+    this.layer = layer;
+    blurriness = blurEffect.getBlurriness().createAnimation();
+    blurriness.addUpdateListener(this);
+    layer.addAnimation(blurriness);
+  }
+
+  @Override public void onValueChanged() {
+    listener.onValueChanged();
+  }
+
+  /**
+   * Evaluates the blur at this layer, returning a BlurMaskFilter-compatible blur
+   * parameter (by convention). Other implementations will need adjustment.
+   */
+  public float evaluate(Matrix parentMatrix) {
+    float rawBlurriness = blurriness.getValue();
+
+    float parentScale = parentMatrix.mapRadius(1.0f);
+    float layerScale = layer.transform.getMatrix().mapRadius(1.0f);
+
+    // Similarly to shadows, the blur radius is provided relative to the layer post-,
+    // not pre-transform. For this reason, we should undo the layer's transformation
+    // here --- if the layer is scaled, the screen-space blur should stay constant.
+    float factor = parentScale * (1 / layerScale);
+
+    return rawBlurriness * factor;
+  }
+
+  public void setBlurrinessCallback(@Nullable LottieValueCallback<Float> callback) {
+    blurriness.setValueCallback(callback);
+  }
+}

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/BaseLayer.java
@@ -232,7 +232,7 @@ public abstract class BaseLayer
   }
 
   @Override
-  public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply) {
+  public void draw(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply, float blurToApply) {
     L.beginSection(drawTraceName);
     if (!visible || layerModel.isHidden()) {
       L.endSection(drawTraceName);
@@ -267,7 +267,7 @@ public abstract class BaseLayer
       if (L.isTraceEnabled()) {
         L.beginSection("Layer#drawLayer");
       }
-      drawLayer(canvas, matrix, alpha, shadowToApply);
+      drawLayer(canvas, matrix, alpha, shadowToApply, blurToApply);
       if (L.isTraceEnabled()) {
         L.endSection("Layer#drawLayer");
       }
@@ -340,7 +340,7 @@ public abstract class BaseLayer
       if (L.isTraceEnabled()) {
         L.beginSection("Layer#drawLayer");
       }
-      drawLayer(canvas, matrix, alpha, shadowToApply);
+      drawLayer(canvas, matrix, alpha, shadowToApply, blurToApply);
       if (L.isTraceEnabled()) {
         L.endSection("Layer#drawLayer");
       }
@@ -360,7 +360,7 @@ public abstract class BaseLayer
         }
         clearCanvas(canvas);
         //noinspection ConstantConditions
-        matteLayer.draw(canvas, parentMatrix, alpha, null);
+        matteLayer.draw(canvas, parentMatrix, alpha, null, 0);
         if (L.isTraceEnabled()) {
           L.beginSection("Layer#restoreLayer");
         }
@@ -485,7 +485,7 @@ public abstract class BaseLayer
     }
   }
 
-  abstract void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply);
+  abstract void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply, float blurToApply);
 
   private void applyMasks(Canvas canvas, Matrix matrix) {
     if (L.isTraceEnabled()) {

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/NullLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/NullLayer.java
@@ -13,7 +13,7 @@ public class NullLayer extends BaseLayer {
     super(lottieDrawable, layerModel);
   }
 
-  @Override void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply) {
+  @Override void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply, float blurToApply) {
     // Do nothing.
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/ShapeLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/ShapeLayer.java
@@ -13,6 +13,7 @@ import com.airbnb.lottie.LottieDrawable;
 import com.airbnb.lottie.LottieProperty;
 import com.airbnb.lottie.animation.content.Content;
 import com.airbnb.lottie.animation.content.ContentGroup;
+import com.airbnb.lottie.animation.keyframe.BlurKeyframeAnimation;
 import com.airbnb.lottie.animation.keyframe.DropShadowKeyframeAnimation;
 import com.airbnb.lottie.model.KeyPath;
 import com.airbnb.lottie.model.content.BlurEffect;
@@ -28,6 +29,7 @@ public class ShapeLayer extends BaseLayer {
   private final CompositionLayer compositionLayer;
 
   @Nullable private DropShadowKeyframeAnimation dropShadowAnimation;
+  @Nullable private BlurKeyframeAnimation blurAnimation;
 
   ShapeLayer(LottieDrawable lottieDrawable, Layer layerModel, CompositionLayer compositionLayer, LottieComposition composition) {
     super(lottieDrawable, layerModel);
@@ -41,14 +43,20 @@ public class ShapeLayer extends BaseLayer {
     if (getDropShadowEffect() != null) {
       dropShadowAnimation = new DropShadowKeyframeAnimation(this, this, getDropShadowEffect());
     }
+
+    if (getBlurEffect() != null) {
+      blurAnimation = new BlurKeyframeAnimation(this, this, getBlurEffect());
+    }
   }
 
-  @Override void drawLayer(@NonNull Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow parentShadowToApply) {
+  @Override void drawLayer(@NonNull Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow parentShadowToApply, float parentBlurToApply) {
     // If a parent composition layer has a shadow and we have one too, prioritize our own.
     DropShadow shadowToApply = dropShadowAnimation != null
         ? dropShadowAnimation.evaluate(parentMatrix, parentAlpha)
         : parentShadowToApply;
-    contentGroup.draw(canvas, parentMatrix, parentAlpha, shadowToApply);
+    float blurToApply = parentBlurToApply +
+        (blurAnimation != null ? blurAnimation.evaluate(parentMatrix) : 0.0f);
+    contentGroup.draw(canvas, parentMatrix, parentAlpha, shadowToApply, blurToApply);
   }
 
   @Override public void getBounds(RectF outBounds, Matrix parentMatrix, boolean applyParents) {
@@ -84,6 +92,8 @@ public class ShapeLayer extends BaseLayer {
       dropShadowAnimation.setDistanceCallback((LottieValueCallback<Float>) callback);
     } else if (property == LottieProperty.DROP_SHADOW_RADIUS && dropShadowAnimation != null) {
       dropShadowAnimation.setRadiusCallback((LottieValueCallback<Float>) callback);
+    } else if (property == LottieProperty.BLUR_RADIUS && blurAnimation != null) {
+      blurAnimation.setBlurrinessCallback((LottieValueCallback<Float>) callback);
     }
   }
 }

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/SolidLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/SolidLayer.java
@@ -37,7 +37,7 @@ public class SolidLayer extends BaseLayer {
     paint.setColor(layerModel.getSolidColor());
   }
 
-  @Override public void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply) {
+  @Override public void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply, float blurToApply) {
     int backgroundAlpha = Color.alpha(layerModel.getSolidColor());
     if (backgroundAlpha == 0) {
       return;
@@ -58,6 +58,8 @@ public class SolidLayer extends BaseLayer {
     } else {
       paint.clearShadowLayer();
     }
+
+    paint.setMaskFilter(getBlurMaskFilter(blurToApply));
 
     if (colorFilterAnimation != null) {
       paint.setColorFilter(colorFilterAnimation.getValue());

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/TextLayer.java
@@ -159,7 +159,7 @@ public class TextLayer extends BaseLayer {
   }
 
   @Override
-  void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply /* ignored for now */) {
+  void drawLayer(Canvas canvas, Matrix parentMatrix, int parentAlpha, @Nullable DropShadow shadowToApply /* ignored for now */, float blurToApply /* ignored for now */) {
     DocumentData documentData = textAnimation.getValue();
     Font font = composition.getFonts().get(documentData.fontName);
     if (font == null) {

--- a/lottie/src/main/java/com/airbnb/lottie/parser/BlurEffectParser.java
+++ b/lottie/src/main/java/com/airbnb/lottie/parser/BlurEffectParser.java
@@ -54,6 +54,7 @@ class BlurEffectParser {
         case 1:
           if (isCorrectType) {
             blurEffect = new BlurEffect(AnimatableValueParser.parseFloat(reader, composition));
+            break;
           } else {
             reader.skipValue();
           }

--- a/lottie/src/main/java/com/airbnb/lottie/utils/FastBlur.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/FastBlur.java
@@ -1,0 +1,155 @@
+package com.airbnb.lottie.utils;
+
+import android.graphics.Bitmap;
+
+public class FastBlur {
+
+  /**
+   * WIP: Fast blur implementation
+   * <p>
+   * Still to do:
+   * - Reuse arrays
+   * - Use a Buffer to avoid unnecessary copies or colorspace conversions
+   * - Try to get ART to autovectorize the code (if at all possible)
+   * - Experiment with alternatives e.g. one-per-channel BlurMaskFilter
+   */
+  public static void apply(Bitmap image, int radius) {
+    radius /= 7; // Normalize the looks of the blur to what BlurMaskFilter produces
+    if (radius < 1) {
+      return;
+    }
+
+    int width = image.getWidth();
+    int height = image.getHeight();
+    int totalPixels = width * height;
+    int kernelSize = 2 * radius + 1;
+
+    int[] sumsByChannel = new int[4];
+    int x, y, i;
+    int pixelValue, pixel1, pixel2;
+    int yPosition, pixelIndex, yWidth;
+
+    int[] pixels = new int[totalPixels];
+    char[] dst = new char[4 * totalPixels];
+
+    // Get the pixel data from the image
+    image.setPremultiplied(false);
+    image.getPixels(pixels, 0, width, 0, 0, width, height);
+
+    yWidth = pixelIndex = 0;
+
+    // Horizontal blur
+    for (y = 0; y < height; y++) {
+      for (int channel = 0; channel < 4; channel++) {
+        sumsByChannel[channel] = 0;
+      }
+
+      // Accumulate the sum of the color channels within the radius
+      for (i = -radius; i <= radius; i++) {
+        pixelValue = pixels[pixelIndex + Math.min(width - 1, Math.max(i, 0))];
+        sumsByChannel[0] += getRed(pixelValue);
+        sumsByChannel[1] += getGreen(pixelValue);
+        sumsByChannel[2] += getBlue(pixelValue);
+        sumsByChannel[3] += getAlpha(pixelValue);
+      }
+
+      for (x = 0; x < width; x++) {
+        // Assign the average to the blur arrays
+        int outIdx = 4 * pixelIndex;
+        for (int channel = 0; channel < 4; channel++) {
+          dst[outIdx++] = (char) (sumsByChannel[channel] / kernelSize);
+        }
+
+        // Subtract the left pixel and add the right pixel
+        int minVal = Math.min(x + radius + 1, width - 1);
+        int maxVal = Math.max(x - radius, 0);
+
+        pixel1 = pixels[yWidth + minVal];
+        pixel2 = pixels[yWidth + maxVal];
+
+        sumsByChannel[0] += getRed(pixel1) - getRed(pixel2);
+        sumsByChannel[1] += getGreen(pixel1) - getGreen(pixel2);
+        sumsByChannel[2] += getBlue(pixel1) - getBlue(pixel2);
+        sumsByChannel[3] += getAlpha(pixel1) - getAlpha(pixel2);
+
+        pixelIndex++;
+      }
+
+      yWidth += width;
+    }
+
+    // Vertical blur
+    for (x = 0; x < width; x++) {
+      for (int channel = 0; channel < 4; channel++) {
+        sumsByChannel[channel] = 0;
+      }
+
+      yPosition = -radius * width;
+
+      // Accumulate the sum over the radius
+      for (i = -radius; i <= radius; i++) {
+        pixelIndex = Math.max(0, yPosition) + x;
+
+        // Assign the average to the blur arrays
+        int outIdx = 4 * pixelIndex;
+        for (int channel = 0; channel < 4; channel++) {
+          dst[outIdx++] = (char) (sumsByChannel[channel] / kernelSize);
+        }
+
+        yPosition += width;
+      }
+
+      pixelIndex = x;
+      for (y = 0; y < height; y++) {
+        pixels[pixelIndex] =
+            setColor(sumsByChannel[3] / kernelSize, sumsByChannel[0] / kernelSize, sumsByChannel[1] / kernelSize, sumsByChannel[2] / kernelSize);
+
+        int minVal = (Math.min(y + radius + 1, height - 1)) * width;
+        int maxVal = (Math.max(y - radius, 0)) * width;
+
+        // Subtract the top pixel and add the bottom pixel
+        int pixel1Red = dst[4 * (x + minVal) + 0];
+        int pixel1Green = dst[4 * (x + minVal) + 1];
+        int pixel1Blue = dst[4 * (x + minVal) + 2];
+        int pixel1Alpha = dst[4 * (x + minVal) + 3];
+
+        int pixel2Red = dst[4 * (x + maxVal) + 0];
+        int pixel2Green = dst[4 * (x + maxVal) + 1];
+        int pixel2Blue = dst[4 * (x + maxVal) + 2];
+        int pixel2Alpha = dst[4 * (x + maxVal) + 3];
+
+        sumsByChannel[0] += pixel1Red - pixel2Red;
+        sumsByChannel[1] += pixel1Green - pixel2Green;
+        sumsByChannel[2] += pixel1Blue - pixel2Blue;
+        sumsByChannel[3] += pixel1Alpha - pixel2Alpha;
+
+        pixelIndex += width;
+      }
+    }
+
+    // Set the blurred pixels back to the image
+    image.setPixels(pixels, 0, width, 0, 0, width, height);
+    image.setPremultiplied(true);
+  }
+
+  // Helper methods to extract and set color components
+  private static int getAlpha(int color) {
+    return (color >> 24) & 0xFF;
+  }
+
+  private static int getRed(int color) {
+    return (color >> 16) & 0xFF;
+  }
+
+  private static int getGreen(int color) {
+    return ((color >> 8) & 0xFF);
+  }
+
+  private static int getBlue(int color) {
+    return (color & 0xFF);
+  }
+
+  private static int setColor(int alpha, int red, int green, int blue) {
+    return (alpha << 24) | (red << 16) | (green << 8) | blue;
+  }
+}

--- a/lottie/src/main/java/com/airbnb/lottie/utils/OffscreenLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/OffscreenLayer.java
@@ -164,7 +164,7 @@ public class OffscreenLayer {
 
     // Beyond this point, we are sure that we need to render a drop shadow or blur.
 
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || true) { // !parentCanvas.isHardwareAccelerated()) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || !parentCanvas.isHardwareAccelerated()) {
       // We don't have support for the RenderNode API, or we're rendering to a software canvas
       // which doesn't support RenderNodes anyhow. This is the slowest path: render to a bitmap,
       // add a shadow/blur manually on CPU.

--- a/lottie/src/main/res/values/attrs.xml
+++ b/lottie/src/main/res/values/attrs.xml
@@ -18,7 +18,10 @@
         <attr name="lottie_progress" format="float" />
         <attr name="lottie_enableMergePathsForKitKatAndAbove" format="boolean" />
         <attr name="lottie_applyOpacityToLayers" format="boolean" />
+        <!-- applyShadowToLayers is just an alias for applyEffectsToLayers,
+             provided only for backwards compatibility. -->
         <attr name="lottie_applyShadowToLayers" format="boolean" />
+        <attr name="lottie_applyEffectsToLayers" format="boolean" />
         <attr name="lottie_colorFilter" format="color" />
         <attr name="lottie_speed" format="float" />
         <attr name="lottie_cacheComposition" format="boolean" />


### PR DESCRIPTION
Analogously to drop shadows in #2548, allow blurs to be applied to composition and image layers using the new `OffscreenLayer`.

Rename `applyShadowToLayers` to `applyEffectsToLayers` and use it for both of these effects. Keep externally-facing `applyShadowToLayers` and forward to `applyEffectsToLayers` for backwards compat.

Undo the layer transform when computing the radius of a blur effect, similarly as we do for shadows.

Use fast hardware blur using RenderEffect if possible, and otherwise delegate to a "reasonably fast" box-blur implementation on the CPU.

**This is not the final version. Still to do:**
* Try to optimize FastBlur more
* Check behavior on existing testcases to ensure no regressions
* Match the scaling constants between implementations to ensure the blur appears the same as in lottie-web, the same with `applyEffectsToLayers` and without, and the same with hardware vs software implementation of blur.