### PR TITLE
Fix NPE a Bitmap reference at the Utils.resizeBitmapIfNeeded

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
+++ b/lottie/src/main/java/com/airbnb/lottie/manager/ImageAssetManager.java
@@ -106,7 +106,19 @@ public class ImageAssetManager {
         Logger.warning("data URL did not have correct base64 format.", e);
         return null;
       }
-      bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, opts);
+
+      try {
+        bitmap = BitmapFactory.decodeByteArray(data, 0, data.length, opts);
+      } catch (IllegalArgumentException e) {
+        Logger.warning("Unable to decode image `" + id + "`.", e);
+        return null;
+      }
+
+      if (bitmap == null) {
+        Logger.warning("Decoded image `" + id + "` is null.");
+        return null;
+      }
+
       Bitmap resizedBitmap = Utils.resizeBitmapIfNeeded(bitmap, asset.getWidth(), asset.getHeight());
       return putBitmap(id, resizedBitmap);
     }

--- a/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/Utils.java
@@ -280,7 +280,7 @@ public final class Utils {
    * Resize the bitmap to exactly the same size as the specified dimension, changing the aspect ratio if needed.
    * Returns the original bitmap if the dimensions already match.
    */
-  public static Bitmap resizeBitmapIfNeeded(Bitmap bitmap, int width, int height) {
+  public static Bitmap resizeBitmapIfNeeded(@NonNull Bitmap bitmap, int width, int height) {
     if (bitmap.getWidth() == width && bitmap.getHeight() == height) {
       return bitmap;
     }


### PR DESCRIPTION
Occur NPE in the Utils.resizeBitmapIfNeeded if referenced Bitmap is null object.

Code modify similar way ImageAssetManager.bitmapForId method (line 138~148)

```
java.lang.NullPointerException: Attempt to invoke virtual method 'int android.graphics.Bitmap.getWidth()' on a null object reference
        at com.airbnb.lottie.utils.Utils.resizeBitmapIfNeeded(Utils:284)
        at com.airbnb.lottie.manager.ImageAssetManager.bitmapForId(ImageAssetManager:110)
        at com.airbnb.lottie.LottieDrawable.getBitmapForId(LottieDrawable:1564)
        at com.airbnb.lottie.model.layer.ImageLayer.getBitmap(ImageLayer:125)
        at com.airbnb.lottie.model.layer.ImageLayer.drawLayer(ImageLayer:49)
        at com.airbnb.lottie.model.layer.BaseLayer.draw(BaseLayer:270)
        at com.airbnb.lottie.model.layer.CompositionLayer.drawLayer(CompositionLayer:161)
        at com.airbnb.lottie.model.layer.BaseLayer.draw(BaseLayer:270)
        at com.airbnb.lottie.LottieDrawable.drawDirectlyToCanvas(LottieDrawable:1751)
        at com.airbnb.lottie.LottieDrawable.draw(LottieDrawable:758)
        at android.widget.ImageView.onDraw(ImageView.java:1446)
 ```