### PR TITLE
Prevent NPE in ImageLayer.getBounds()

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
@@ -110,6 +110,9 @@ public class ImageLayer extends BaseLayer {
         Bitmap bitmap = getBitmap();
         if (bitmap != null) {
           outBounds.set(0, 0, bitmap.getWidth() * scale, bitmap.getHeight() * scale);
+        } else {
+          // If the bitmap is null, we aren't rendering anything, so set outBounds to an empty rectangle
+          outBounds.set(0, 0, 0, 0);
         }
       }
       boundsMatrix.mapRect(outBounds);

--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
@@ -107,7 +107,10 @@ public class ImageLayer extends BaseLayer {
       if (lottieDrawable.getMaintainOriginalImageBounds()) {
         outBounds.set(0, 0, lottieImageAsset.getWidth() * scale, lottieImageAsset.getHeight() * scale);
       } else {
-        outBounds.set(0, 0, getBitmap().getWidth() * scale, getBitmap().getHeight() * scale);
+        Bitmap bitmap = getBitmap();
+        if (bitmap != null) {
+          outBounds.set(0, 0, bitmap.getWidth() * scale, bitmap.getHeight() * scale);
+        }
       }
       boundsMatrix.mapRect(outBounds);
     }


### PR DESCRIPTION
The recent [improvements to drop shadows](https://github.com/airbnb/lottie-android/pull/2548/files#diff-31e777f53a917d69dcf1b234ae6c77db843316c34911e200d0a9a160c058b621R110) added a dereference of a nullable result from the `getBitmap()` call.

Fixes #2601 