### PR TITLE
Fix floating point errors calculating keyframe end progress

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/value/Keyframe.java
+++ b/lottie/src/main/java/com/airbnb/lottie/value/Keyframe.java
@@ -137,6 +137,12 @@ public class Keyframe<T> {
   }
 
   public boolean containsProgress(@FloatRange(from = 0f, to = 1f) float progress) {
+    // The containsRange check is closed on both sides.
+    // Ideally, it would be open at the end and all keyframes would be perfectly
+    // overlapping. However, due to floating point rounding errors, it is possible to have
+    // two keyframes in which one ends at 45.99998 and the next starts at 45.99999.
+    // If the progress happens to be exactly 45.99998 then it wouldn't match either keyframe
+    // unless the upper bound is closed.
     return progress >= getStartProgress() && progress <= getEndProgress();
   }
 

--- a/lottie/src/main/java/com/airbnb/lottie/value/Keyframe.java
+++ b/lottie/src/main/java/com/airbnb/lottie/value/Keyframe.java
@@ -125,8 +125,8 @@ public class Keyframe<T> {
       } else {
         float startProgress = getStartProgress();
         float durationFrames = endFrame - startFrame;
-        float durationProgress = durationFrames / composition.getDurationFrames();
-        endProgress = startProgress + durationProgress;
+        double durationProgress = durationFrames / (double) composition.getDurationFrames();
+        endProgress = (float) (startProgress + durationProgress);
       }
     }
     return endProgress;
@@ -137,13 +137,7 @@ public class Keyframe<T> {
   }
 
   public boolean containsProgress(@FloatRange(from = 0f, to = 1f) float progress) {
-    // The containsRange check is closed on both sides.
-    // Ideally, it would be open at the end and all keyframes would be perfectly
-    // overlapping. However, due to floating point rounding errors, it is possible to have
-    // two keyframes in which one ends at 45.99998 and the next starts at 45.99999.
-    // If the progress happens to be exactly 45.99998 then it wouldn't match either keyframe
-    // unless the upper bound is closed.
-    return progress >= getStartProgress() && progress <= getEndProgress();
+    return progress >= getStartProgress() && progress < getEndProgress();
   }
 
   /**

--- a/lottie/src/main/java/com/airbnb/lottie/value/Keyframe.java
+++ b/lottie/src/main/java/com/airbnb/lottie/value/Keyframe.java
@@ -137,7 +137,7 @@ public class Keyframe<T> {
   }
 
   public boolean containsProgress(@FloatRange(from = 0f, to = 1f) float progress) {
-    return progress >= getStartProgress() && progress < getEndProgress();
+    return progress >= getStartProgress() && progress <= getEndProgress();
   }
 
   /**

--- a/lottie/src/test/java/com/airbnb/lottie/value/KeyframeTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/value/KeyframeTest.java
@@ -30,11 +30,11 @@ public class KeyframeTest {
         new SparseArrayCompat<>(),
         new HashMap<>(),
         new ArrayList<>(),
-        1400,
-        600
+        0,
+        0
     );
     Keyframe<Float> keyframe1 = new Keyframe<>(composition, 200f, 321f, new LinearInterpolator(), 28f, 48f);
     Keyframe<Float> keyframe2 = new Keyframe<>(composition, 321f, 300f, new LinearInterpolator(), 48f, 56f);
-    assertEquals(keyframe1.getEndProgress(), keyframe2.getStartProgress(), 0f);
+    assertEquals(keyframe2.getStartProgress(), keyframe1.getEndProgress(), 0f);
   }
 }

--- a/lottie/src/test/java/com/airbnb/lottie/value/KeyframeTest.java
+++ b/lottie/src/test/java/com/airbnb/lottie/value/KeyframeTest.java
@@ -1,0 +1,40 @@
+package com.airbnb.lottie.value;
+
+import static org.junit.Assert.*;
+
+import android.graphics.Rect;
+import android.view.animation.LinearInterpolator;
+import androidx.collection.LongSparseArray;
+import androidx.collection.SparseArrayCompat;
+import com.airbnb.lottie.LottieComposition;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class KeyframeTest {
+
+  @Test
+  public void testStartFrame() {
+    LottieComposition composition = new LottieComposition();
+    composition.init(
+        new Rect(),
+        0f,
+        504.99f,
+        60f,
+        new ArrayList<>(),
+        new LongSparseArray<>(),
+        new HashMap<>(),
+        new HashMap<>(),
+        1f,
+        new SparseArrayCompat<>(),
+        new HashMap<>(),
+        new ArrayList<>(),
+        1400,
+        600
+    );
+    Keyframe<Float> keyframe1 = new Keyframe<>(composition, 200f, 321f, new LinearInterpolator(), 28f, 48f);
+    Keyframe<Float> keyframe2 = new Keyframe<>(composition, 321f, 300f, new LinearInterpolator(), 48f, 56f);
+    assertEquals(keyframe1.getEndProgress(), keyframe2.getStartProgress(), 0f);
+  }
+}


### PR DESCRIPTION
This fixed a really tricky bug that led to the wrong keyframe being used due to a floating point rounding error.
Given specific composition start frames and the existing floating point rounding, you could wind up with the following situation:
* Keyframe 1 has an endFrame of 48 and an endProgress of 0.095051385
* Keyframe 2 has a startFrame of 48 and a startProgress of 0.09505139

The [Keyframe.containsProgress](https://github.com/airbnb/lottie-android/blob/master/lottie/src/main/java/com/airbnb/lottie/value/Keyframe.java#L140) check intentionally leaves the upper end of the range open to make it unambiguous that the progress on the boundary of two keyframes should use the latter one.

However, due to this floating point error, there was a gap and if the progress == the endProgress of the first keyframe, it wouldn't match either.

I was able to reconstruct this specific scenario with a unit test and confirmed that this fixed it. However, it is not impossible that there are other scenarios in which this could happen. However, I would rather avoid allocating doubles for everything which is more expensive unless we find a specific repro again