### PR TITLE
remove unhandled exception in default failure listener

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -112,7 +112,7 @@ import java.util.zip.ZipInputStream;
       if (targetView.fallbackResource != 0) {
         targetView.setImageResource(targetView.fallbackResource);
       }
-      LottieListener<Throwable> l = targetView.failureListener == null ? DEFAULT_FAILURE_LISTENER : targetView.failureListener;
+      LottieListener<Throwable> l = targetView.failureListener;
       l.onResult(result);
     }
   }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -71,7 +71,7 @@ import java.util.zip.ZipInputStream;
       Logger.warning("Unable to load composition.", throwable);
       return;
     }
-    throw new IllegalStateException("Unable to parse composition", throwable);
+    Logger.warning("Unable to parse composition", throwable);
   };
 
   private final LottieListener<LottieComposition> loadedListener = new WeakSuccessListener(this);
@@ -112,12 +112,12 @@ import java.util.zip.ZipInputStream;
       if (targetView.fallbackResource != 0) {
         targetView.setImageResource(targetView.fallbackResource);
       }
-      LottieListener<Throwable> l = targetView.failureListener;
+      LottieListener<Throwable> l = targetView.failureListener == null ? DEFAULT_FAILURE_LISTENER : targetView.failureListener;
       l.onResult(result);
     }
   }
 
-  @NonNull private LottieListener<Throwable> failureListener = result -> {};
+  @NonNull private LottieListener<Throwable> failureListener = DEFAULT_FAILURE_LISTENER;
   @DrawableRes private int fallbackResource = 0;
 
   private final LottieDrawable lottieDrawable = new LottieDrawable();

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -112,12 +112,12 @@ import java.util.zip.ZipInputStream;
       if (targetView.fallbackResource != 0) {
         targetView.setImageResource(targetView.fallbackResource);
       }
-      LottieListener<Throwable> l = targetView.failureListener == null ? DEFAULT_FAILURE_LISTENER : targetView.failureListener;
+      LottieListener<Throwable> l = targetView.failureListener;
       l.onResult(result);
     }
   }
 
-  @Nullable private LottieListener<Throwable> failureListener;
+  @NonNull private LottieListener<Throwable> failureListener = result -> {};
   @DrawableRes private int fallbackResource = 0;
 
   private final LottieDrawable lottieDrawable = new LottieDrawable();
@@ -615,7 +615,7 @@ import java.util.zip.ZipInputStream;
    * <p>
    * Set the listener to null to revert to the default behavior.
    */
-  public void setFailureListener(@Nullable LottieListener<Throwable> failureListener) {
+  public void setFailureListener(@NonNull LottieListener<Throwable> failureListener) {
     this.failureListener = failureListener;
   }
 


### PR DESCRIPTION
Issue: https://github.com/airbnb/lottie-android/issues/2271

Description:
Currently if there is no failure listener being set to the `LottieAnimationView` the `DEFAULT_FAILURE_LISTENER` is used, which throws an unhandled exception on the main thread, which causes app to crash. There is no graceful handling in an event a developer forgets to set this explicitly. The same scenario isn't there for [lottie-ios](https://github.com/airbnb/lottie-ios). This is reproducible if by mistake an invalid url is passed to `LottieAnimationView` or a malformed lottie json asset is passed. Either way the component throws an unhandled exception and this is a big issue with production grade apps.

Solution:
As a fix, in the `DEFAULT_FAILURE_LISTENER` logging the exception instead of throwing it. Have also made the top level `failureListener` as non-null so that developers won't accidentally replace the `DEFAULT_FAILURE_LISTENER`.