### PR TITLE
Partially revert previous change to ImageLayer.getBounds()

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
@@ -111,8 +111,8 @@ public class ImageLayer extends BaseLayer {
         if (bitmap != null) {
           outBounds.set(0, 0, bitmap.getWidth() * scale, bitmap.getHeight() * scale);
         } else {
-          // If the bitmap is null, we aren't rendering anything, so set outBounds to an empty rectangle
-          outBounds.set(0, 0, 0, 0);
+          // If the bitmap is null, fall back to using the width and height of the LottieImageAsset
+          outBounds.set(0, 0, lottieImageAsset.getWidth() * scale, lottieImageAsset.getHeight() * scale);
         }
       }
       boundsMatrix.mapRect(outBounds);


### PR DESCRIPTION
The changes in https://github.com/airbnb/lottie-android/pull/2578 set the bounds returned by `ImageLayer.getBounds()` to have 0 width and 0 height if there is no Bitmap available. This change instead calls the previous version of the logic which reads the width and height of the `LottieImageAsset`.