### PR TITLE
Guard against Bitmap allocations of size 0

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/utils/OffscreenLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/OffscreenLayer.java
@@ -186,7 +186,11 @@ public class OffscreenLayer {
     // still being relatively speedy to blit and operate on.
     int width = (int)Math.ceil(bounds.width() * 1.05);
     int height = (int)Math.ceil(bounds.height() * 1.05);
-    return Bitmap.createBitmap(width, height, cfg);
+
+    // In certain cases the provided bounds can have a width or height of 0, which will cause a runtime crash
+    // when we try to allocate a Bitmap. To guard against this, use a minimum size of 1x1.
+    // See https://github.com/airbnb/lottie-android/issues/2620
+    return Bitmap.createBitmap(Math.max(width, 1), Math.max(height, 1), cfg);
   }
 
   private void deallocateBitmap(Bitmap bitmap) {


### PR DESCRIPTION
Fixes https://github.com/airbnb/lottie-android/issues/2620, which only occurs on Android 12 devices.

See [my branch](https://github.com/airbnb/lottie-android/compare/master...allenchen1154:lottie-android:allen--bitmap-crash-repro?expand=1) for a repro example.

With the fix:

https://github.com/user-attachments/assets/19fcd7b4-9a11-4200-80fb-0868cd62b0d4

