### PR TITLE
Fix crash when drawing shadow on image using RenderNode

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/model/layer/ImageLayer.java
@@ -95,6 +95,9 @@ public class ImageLayer extends BaseLayer {
 
     if (renderOffScreen) {
       offscreenLayer.finish();
+      if (offscreenLayer.finishDecrementsCanvasSaveCount()) {
+        return; // Don't need a restore() call since it's handled by OffscreenLayer
+      }
     }
 
     targetCanvas.restore();

--- a/lottie/src/main/java/com/airbnb/lottie/utils/OffscreenLayer.java
+++ b/lottie/src/main/java/com/airbnb/lottie/utils/OffscreenLayer.java
@@ -553,4 +553,12 @@ public class OffscreenLayer {
     targetCanvas.drawRenderNode(shadowRenderNode);
     targetCanvas.restore();
   }
+
+  /**
+   * Whether calling finish() will decrement the save count of the [Canvas] returned by [start()].
+   */
+  public boolean finishDecrementsCanvasSaveCount() {
+    // endRecording() will decrement the save count of the Canvas returned by beginRecording()
+    return currentStrategy == RenderStrategy.RENDER_NODE;
+  }
 }


### PR DESCRIPTION
When using the RenderNode rendering strategy, the call to `OffscreenLayer.finish()` decrements the save count on the `Canvas` returned from `OffscreenLayer.start()`, so we need to know whether to skip the call to `Canvas.restore()` in `ImageLayer`, otherwise the `Canvas` will thrown an exception.

Fixes https://github.com/airbnb/lottie-android/issues/2609