### PR TITLE
Publish to central.sonatype.com

### DIFF
--- a/lottie-compose/build.gradle
+++ b/lottie-compose/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 mavenPublishing {
-  publishToMavenCentral(SonatypeHost.DEFAULT)
+  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
   signAllPublications()
 }
 

--- a/lottie/build.gradle
+++ b/lottie/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 mavenPublishing {
-  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
   signAllPublications()
 }
 

--- a/lottie/build.gradle
+++ b/lottie/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 mavenPublishing {
-  publishToMavenCentral(SonatypeHost.DEFAULT)
+  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
   signAllPublications()
 }
 

--- a/versions.properties
+++ b/versions.properties
@@ -364,7 +364,7 @@ plugin.org.ajoberstar.grgit=5.2.0
 ##              # available=5.2.2-rc.2
 ##              # available=5.2.2
 
-plugin.com.vanniktech.maven.publish=0.25.2
+plugin.com.vanniktech.maven.publish=0.32.0
 ##                      # available=0.25.3-rc1
 ##                      # available=0.25.3
 ##                      # available=0.26.0-rc1


### PR DESCRIPTION
See [Sonatype documentation](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/) for more details on the differences. The current publishing method (OSSRH) is being sunset on June 30th, 2025. New users can no longer be onboarded to the Nexus Repository Manager, which means they must use the newer Central Portal to publish.

See [plugin documentation](https://vanniktech.github.io/gradle-maven-publish-plugin/central/#configuring-maven-central) for more details.

This will require developers to generate new tokens on Sonatype, as the old OSSRH tokens will no longer work.