### PR TITLE
In DefaultLottieFetchResult, catch NPE from getErrorFromConnection()

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/network/DefaultLottieFetchResult.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/DefaultLottieFetchResult.java
@@ -42,7 +42,7 @@ public class DefaultLottieFetchResult implements LottieFetchResult {
     try {
       return isSuccessful() ? null :
           "Unable to fetch " + connection.getURL() + ". Failed with " + connection.getResponseCode() + "\n" + getErrorFromConnection(connection);
-    } catch (IOException e) {
+    } catch (IOException | NullPointerException e) {
       Logger.warning("get error failed ", e);
       return e.getMessage();
     }


### PR DESCRIPTION
The getErrorFromConnection() method attempts to construct an InputStreamReader, passing in HttpURLConnection.getErrorStream() as the constructor's arg. According to the doc for HttpURLConnection.getErrorStream(), this method can return null if there have been no errors, the connection is not connected or the server sent no useful data. The InputStreamReader(InputStream) constructor passes its arg to java.io.Reader, and that class throws an NPE if the arg is null.