### PR TITLE
Enable path interpolator cache by default

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/L.java
+++ b/lottie/src/main/java/com/airbnb/lottie/L.java
@@ -25,7 +25,7 @@ public class L {
 
   private static boolean traceEnabled = false;
   private static boolean networkCacheEnabled = true;
-  private static boolean disablePathInterpolatorCache = true;
+  private static boolean disablePathInterpolatorCache = false;
   private static AsyncUpdates defaultAsyncUpdates = AsyncUpdates.AUTOMATIC;
 
   private static LottieNetworkFetcher fetcher;

--- a/lottie/src/main/java/com/airbnb/lottie/LottieConfig.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieConfig.java
@@ -45,7 +45,7 @@ public class LottieConfig {
     private LottieNetworkCacheProvider cacheProvider;
     private boolean enableSystraceMarkers = false;
     private boolean enableNetworkCache = true;
-    private boolean disablePathInterpolatorCache = true;
+    private boolean disablePathInterpolatorCache = false;
     private AsyncUpdates defaultAsyncUpdates = AsyncUpdates.AUTOMATIC;
     private ReducedMotionOption reducedMotionOption = new SystemReducedMotionOption();
 


### PR DESCRIPTION
Seems that the flag gets disabled by default due to a mistake in https://github.com/airbnb/lottie-android/pull/2195/files.

This PR sets the default as `private boolean disablePathInterpolatorCache = false`.

This probably might result in some user's test starting to fail as they might never had a need to call `.setDisablePathInterpolatorCache(true)`.

