### PR TITLE
Update compileSDK and targetSDK to 36

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/app-benchmark/build.gradle
+++ b/app-benchmark/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'com.airbnb.lottie.benchmark.app'
-    compileSdk 34
+    compileSdk 36
     defaultConfig {
         applicationId "com.airbnb.lottie.benchmark.app"
         minSdk 21
-        targetSdk 34
+        targetSdk 36
         versionCode 1
         versionName "1.0"
     }

--- a/baselineprofile/build.gradle
+++ b/baselineprofile/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
   namespace 'com.airbnb.lottie.baselineprofile'
-  compileSdk 34
+  compileSdk 36
 
   defaultConfig {
     minSdk 28
-    targetSdk 34
+    targetSdk 36
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.airbnb.lottie.benchmark'
-  compileSdk 34
+  compileSdk 36
 
   kotlinOptions {
     freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
@@ -14,7 +14,7 @@ android {
 
   defaultConfig {
     minSdk 30
-    targetSdk 34
+    targetSdk 36
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/issue-repro-compose/build.gradle
+++ b/issue-repro-compose/build.gradle
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace 'com.airbnb.lottie.issues.compose'
-    compileSdk 34
+    compileSdk 36
     defaultConfig {
         applicationId "com.airbnb.lottie.issues.compose"
         minSdk 21
-        targetSdk 34
+        targetSdk 36
         versionCode 1
         versionName "1.0"
     }

--- a/issue-repro-compose/src/main/kotlin/com/airbnb/lottie/issues/compose/ComposeIssueReproActivity.kt
+++ b/issue-repro-compose/src/main/kotlin/com/airbnb/lottie/issues/compose/ComposeIssueReproActivity.kt
@@ -3,8 +3,12 @@ package com.airbnb.lottie.issues.compose
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.LottieConstants
@@ -23,6 +27,8 @@ class ComposeIssueReproActivity : AppCompatActivity() {
     fun Content() {
         val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.heart))
         val progress by animateLottieCompositionAsState(composition, iterations = LottieConstants.IterateForever)
-        LottieAnimation(composition, { progress })
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            LottieAnimation(composition, { progress })
+        }
     }
 }

--- a/issue-repro/build.gradle
+++ b/issue-repro/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace 'com.airbnb.lottie.issues'
-    compileSdk 34
+    compileSdk 36
     defaultConfig {
         applicationId "com.airbnb.lottie.issues"
         minSdk 16
-        targetSdk 34
+        targetSdk 36
         versionCode 1
         versionName "1.0"
     }

--- a/lottie-compose/build.gradle
+++ b/lottie-compose/build.gradle
@@ -11,10 +11,10 @@ plugins {
 
 android {
   namespace 'com.airbnb.lottie.compose'
-  compileSdk 34
+  compileSdk 36
   defaultConfig {
     minSdk 21
-    targetSdk 34
+    targetSdk 36
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   buildTypes {

--- a/lottie/build.gradle
+++ b/lottie/build.gradle
@@ -11,10 +11,10 @@ plugins {
 android {
   namespace 'com.airbnb.lottie'
   resourcePrefix 'lottie_'
-  compileSdk 34
+  compileSdk 36
   defaultConfig {
     minSdk 16
-    targetSdk 34
+    targetSdk 36
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   lintOptions {

--- a/sample-compose/build.gradle
+++ b/sample-compose/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
   namespace 'com.airbnb.lottie.sample.compose'
-  compileSdk 34
+  compileSdk 36
   defaultConfig {
     applicationId "com.airbnb.lottie.sample.compose"
     minSdk 21
-    targetSdk 34
+    targetSdk 36
     versionCode 1
     versionName VERSION_NAME
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/ComposeActivity.kt
+++ b/sample-compose/src/main/java/com/airbnb/lottie/sample/compose/ComposeActivity.kt
@@ -6,7 +6,16 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.exclude
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.Icon
@@ -59,8 +68,11 @@ class ComposeActivity : AppCompatActivity() {
 
         LottieTheme {
             Scaffold(
+                // Omit bottom inset padding for the scaffold to allow the BottomNavigation to extend to the edge of the screen.
+                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)),
                 bottomBar = {
                     BottomNavigation(
+                        windowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
                         backgroundColor = Color(0xFFF7F7F7),
                         elevation = 8.dp,
                         contentColor = Teal,
@@ -68,7 +80,7 @@ class ComposeActivity : AppCompatActivity() {
                         val navBackStackEntry by navController.currentBackStackEntryAsState()
                         val currentRoute = navBackStackEntry?.destination?.route
 
-                        BottomNavItemData.values().forEach { item ->
+                        BottomNavItemData.entries.forEach { item ->
                             BottomNavigationItem(
                                 icon = {
                                     Icon(

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,11 +9,11 @@ plugins {
 
 android {
   namespace 'com.airbnb.lottie.samples'
-  compileSdk 34
+  compileSdk 36
   defaultConfig {
     applicationId "com.airbnb.lottie"
     minSdk 16
-    targetSdk 34
+    targetSdk 36
     versionCode 71
     versionName VERSION_NAME
     multiDexEnabled true

--- a/sample/src/main/kotlin/com/airbnb/lottie/samples/MainActivity.kt
+++ b/sample/src/main/kotlin/com/airbnb/lottie/samples/MainActivity.kt
@@ -5,6 +5,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import com.airbnb.lottie.samples.databinding.MainActivityBinding
@@ -26,8 +29,26 @@ class MainActivity : AppCompatActivity() {
         }
         binding.bottomNavigation.itemIconTintList = null
 
+        updateContentPaddingForSystemWindowInsets()
+
         if (savedInstanceState == null) {
             showFragment(PreviewFragment())
+        }
+    }
+
+    private fun updateContentPaddingForSystemWindowInsets() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.content) { v, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout(),
+            )
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+                bottom = bars.bottom,
+            )
+            WindowInsetsCompat.CONSUMED
         }
     }
 

--- a/sample/src/main/res/layout/main_activity.xml
+++ b/sample/src/main/res/layout/main_activity.xml
@@ -14,11 +14,11 @@
         android:layout_height="0dp"
         android:layout_weight="1" />
 
-
+    <!--Wrap content height to allow for bottom window insets to be included-->
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigation"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="wrap_content"
         android:background="#F7F7F7"
         android:elevation="8dp"
         app:itemIconTint="@drawable/bottom_bar_tint_list"

--- a/snapshot-tests/build.gradle
+++ b/snapshot-tests/build.gradle
@@ -7,11 +7,11 @@ plugins {
 
 android {
   namespace 'com.airbnb.lottie.snapshots'
-  compileSdk 34
+  compileSdk 36
   defaultConfig {
     applicationId "com.airbnb.lottie.snapshots"
     minSdk 21
-    targetSdk 34
+    targetSdk 36
     versionCode 1
     versionName VERSION_NAME
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
The Google Play Store has a [new requirement](https://developer.android.com/google/play/requirements/target-sdk) that requires apps to target SDK versions that are less than one version/year behind.

This change updates all gradle projects in the repo to version 36, and fixes visual overlap issues in the sample apps caused by edge to edge being enabled by default.

|BEFORE|AFTER|
|-|-|
|<img width="300"  alt="Screenshot_20250806_124417" src="https://github.com/user-attachments/assets/eb809738-1a96-472e-8542-c6a8d8bb61d1" />|<img width="300"  alt="Screenshot_20250806_135726" src="https://github.com/user-attachments/assets/a8c7bf7f-636f-4a49-a9bf-27fccc37d851" />|


Compose sample app with inset padding applied:
<img width="300" alt="Screenshot_20250806_125848" src="https://github.com/user-attachments/assets/545b0e15-96ea-4a2d-ada0-2af8dd24dec6" />
