### PR TITLE
Safeguard against very large Bitmap creation

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java
@@ -111,6 +111,11 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       "reducedmotion"
   );
 
+  /**
+   * Significantly larger than the largest expected size, equivalent to about 1.5x an 8K display.
+   */
+  private static final long MAX_SOFTWARE_BITMAP_PIXELS = 50_000_000L;
+
   private LottieComposition composition;
   private final LottieValueAnimator animator = new LottieValueAnimator();
 
@@ -1795,11 +1800,22 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
       softwareRenderingTransformedBounds.intersect(canvasClipBounds.left, canvasClipBounds.top, canvasClipBounds.right, canvasClipBounds.bottom);
     }
 
+    if (!isFiniteRect(softwareRenderingTransformedBounds)) {
+      Logger.warning("Skipping software rendering: transformed bounds contain non-finite values.");
+      return;
+    }
+
     int renderWidth = (int) Math.ceil(softwareRenderingTransformedBounds.width());
     int renderHeight = (int) Math.ceil(softwareRenderingTransformedBounds.height());
 
-    // Safeguard against errors during Bitmap creation by returning early if dimensions are invalid.
-    if (renderWidth <= 0 || renderHeight <= 0 || renderWidth > bounds.width() || renderHeight > bounds.height()) {
+    if (renderWidth <= 0 || renderHeight <= 0) {
+      Logger.warning("Skipping software rendering: transformed bounds have negative values.");
+      return;
+    }
+
+    long renderPixelCount = (long) renderWidth * (long) renderHeight;
+    if (renderPixelCount > MAX_SOFTWARE_BITMAP_PIXELS) {
+      Logger.warning("Skipping software rendering: bitmap request exceeds safe pixel count (" + renderPixelCount + ")");
       return;
     }
 
@@ -1889,6 +1905,17 @@ public class LottieDrawable extends Drawable implements Drawable.Callback, Anima
         src.top,
         src.right,
         src.bottom);
+  }
+
+  private static boolean isFiniteRect(RectF rect) {
+    return isFinite(rect.left) &&
+        isFinite(rect.top) &&
+        isFinite(rect.right) &&
+        isFinite(rect.bottom);
+  }
+
+  private static boolean isFinite(float value) {
+    return !Float.isNaN(value) && !Float.isInfinite(value);
   }
 
   private void scaleRect(RectF rect, float scaleX, float scaleY) {


### PR DESCRIPTION
Because we rely on the transform `Matrix` returned from the `Canvas` to size a `Bitmap` when using software rendering, an erroneous matrix value can cause a very large Bitmap to be allocated, triggering an OutOfMemory exception.

We've encountered such a situation when using `layoutlib` for screenshot tests, which uses a `NopCanvas` [on initial render](https://cs.android.com/android/_/android/platform/frameworks/layoutlib/+/7b05b277beee599532606e9bb6d7a71f5ca2ab6e:bridge/src/com/android/layoutlib/bridge/impl/RenderSessionImpl.java;l=543;bpv=1;bpt=0;drc=085857f145aac790e2a08cf6eb9546f98e26c338) that can return an invalid `Matrix.