### PR TITLE
Support Lottie to be rendered on per-window UI thread

### DIFF
--- a/lottie-compose/src/main/java/com/airbnb/lottie/compose/rememberLottieComposition.kt
+++ b/lottie-compose/src/main/java/com/airbnb/lottie/compose/rememberLottieComposition.kt
@@ -186,16 +186,19 @@ private fun lottieTask(
                 val actualCacheKey = if (cacheKey == DefaultCacheKey) spec.fileName else cacheKey
                 when {
                     spec.fileName.endsWith("zip") -> LottieCompositionFactory.fromZipStream(
+                        context,
                         ZipInputStream(fis),
                         actualCacheKey,
                     )
 
                     spec.fileName.endsWith("tgs") -> LottieCompositionFactory.fromJsonInputStream(
+                        context,
                         GZIPInputStream(fis),
                         actualCacheKey,
                     )
 
                     else -> LottieCompositionFactory.fromJsonInputStream(
+                        context,
                         fis,
                         actualCacheKey,
                     )
@@ -213,7 +216,7 @@ private fun lottieTask(
 
         is LottieCompositionSpec.JsonString -> {
             val jsonStringCacheKey = if (cacheKey == DefaultCacheKey) spec.jsonString.hashCode().toString() else cacheKey
-            LottieCompositionFactory.fromJsonString(spec.jsonString, jsonStringCacheKey)
+            LottieCompositionFactory.fromJsonString(context, spec.jsonString, jsonStringCacheKey)
         }
 
         is LottieCompositionSpec.ContentProvider -> {

--- a/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java
@@ -492,7 +492,7 @@ import java.util.zip.ZipInputStream;
 
   private LottieTask<LottieComposition> fromRawRes(@RawRes final int rawRes) {
     if (isInEditMode()) {
-      return new LottieTask<>(() -> cacheComposition
+      return new LottieTask<>(getContext().getMainLooper(), () -> cacheComposition
           ? LottieCompositionFactory.fromRawResSync(getContext(), rawRes) : LottieCompositionFactory.fromRawResSync(getContext(), rawRes, null), true);
     } else {
       return cacheComposition ?
@@ -508,7 +508,7 @@ import java.util.zip.ZipInputStream;
 
   private LottieTask<LottieComposition> fromAssets(final String assetName) {
     if (isInEditMode()) {
-      return new LottieTask<>(() -> cacheComposition ?
+      return new LottieTask<>(getContext().getMainLooper(), () -> cacheComposition ?
           LottieCompositionFactory.fromAssetSync(getContext(), assetName) : LottieCompositionFactory.fromAssetSync(getContext(), assetName, null), true);
     } else {
       return cacheComposition ?
@@ -546,7 +546,7 @@ import java.util.zip.ZipInputStream;
    * Auto-closes the stream.
    */
   public void setAnimation(InputStream stream, @Nullable String cacheKey) {
-    setCompositionTask(LottieCompositionFactory.fromJsonInputStream(stream, cacheKey));
+    setCompositionTask(LottieCompositionFactory.fromJsonInputStream(getContext(), stream, cacheKey));
   }
 
   /**
@@ -559,7 +559,7 @@ import java.util.zip.ZipInputStream;
    * Auto-closes the stream.
    */
   public void setAnimation(ZipInputStream stream, @Nullable String cacheKey) {
-    setCompositionTask(LottieCompositionFactory.fromZipStream(stream, cacheKey));
+    setCompositionTask(LottieCompositionFactory.fromZipStream(getContext(), stream, cacheKey));
   }
 
   /**


### PR DESCRIPTION
Issue: #2684

TLDR: Lottie will crash if rendered on per-window UI thread on AOSP launcher. This change will allow app to provide per-window UI thread's looper via overriding `Context#getMainLooper()` to replaced hard coded `Looper` in `LottieTask`

More details in https://github.com/airbnb/lottie-android/issues/2684