### PR TITLE
Fix potential NPE when checking transform identity with null startValue

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/parser/AnimatableTransformParser.java
+++ b/lottie/src/main/java/com/airbnb/lottie/parser/AnimatableTransformParser.java
@@ -12,6 +12,7 @@ import com.airbnb.lottie.model.animatable.AnimatableTransform;
 import com.airbnb.lottie.model.animatable.AnimatableValue;
 import com.airbnb.lottie.parser.moshi.JsonReader;
 import com.airbnb.lottie.value.Keyframe;
+import com.airbnb.lottie.value.ScaleXY;
 
 import java.io.IOException;
 
@@ -160,29 +161,51 @@ public class AnimatableTransformParser {
   }
 
   private static boolean isAnchorPointIdentity(AnimatablePathValue anchorPoint) {
-    return anchorPoint == null || (anchorPoint.isStatic() && anchorPoint.getKeyframes().get(0).startValue.equals(0f, 0f));
+    if (anchorPoint == null) {
+      return true;
+    }
+    PointF startValue = anchorPoint.getKeyframes().get(0).startValue;
+    return anchorPoint.isStatic() && startValue != null && startValue.equals(0f, 0f);
   }
 
   private static boolean isPositionIdentity(AnimatableValue<PointF, PointF> position) {
-    return position == null || (
-        !(position instanceof AnimatableSplitDimensionPathValue) &&
-            position.isStatic() && position.getKeyframes().get(0).startValue.equals(0f, 0f));
+    if (position == null || position instanceof AnimatableSplitDimensionPathValue) {
+      return position == null;
+    }
+    PointF startValue = position.getKeyframes().get(0).startValue;
+    return position.isStatic() && startValue != null && startValue.equals(0f, 0f);
   }
 
   private static boolean isRotationIdentity(AnimatableFloatValue rotation) {
-    return rotation == null || (rotation.isStatic() && rotation.getKeyframes().get(0).startValue == 0f);
+    if (rotation == null) {
+      return true;
+    }
+    Float startValue = rotation.getKeyframes().get(0).startValue;
+    return rotation.isStatic() && startValue != null && startValue == 0f;
   }
 
   private static boolean isScaleIdentity(AnimatableScaleValue scale) {
-    return scale == null || (scale.isStatic() && scale.getKeyframes().get(0).startValue.equals(1f, 1f));
+    if (scale == null) {
+      return true;
+    }
+    ScaleXY startValue = scale.getKeyframes().get(0).startValue;
+    return scale.isStatic() && startValue != null && startValue.equals(1f, 1f);
   }
 
   private static boolean isSkewIdentity(AnimatableFloatValue skew) {
-    return skew == null || (skew.isStatic() && skew.getKeyframes().get(0).startValue == 0f);
+    if (skew == null) {
+      return true;
+    }
+    Float startValue = skew.getKeyframes().get(0).startValue;
+    return skew.isStatic() && startValue != null && startValue == 0f;
   }
 
   private static boolean isSkewAngleIdentity(AnimatableFloatValue skewAngle) {
-    return skewAngle == null || (skewAngle.isStatic() && skewAngle.getKeyframes().get(0).startValue == 0f);
+    if (skewAngle == null) {
+      return true;
+    }
+    Float startValue = skewAngle.getKeyframes().get(0).startValue;
+    return skewAngle.isStatic() && startValue != null && startValue == 0f;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR fixes a potential NullPointerException in `AnimatableTransformParser.java` when checking if transform values are identity transforms.

## The Bug

The identity check methods (`isAnchorPointIdentity`, `isPositionIdentity`, `isRotationIdentity`, `isScaleIdentity`, `isSkewIdentity`, `isSkewAngleIdentity`) were accessing `Keyframe.startValue` without null checks, but `startValue` is annotated as `@Nullable` in `Keyframe.java`:

```java
@Nullable public final T startValue;
```

This would cause a NullPointerException when:
1. For `PointF` values (anchorPoint, position): calling `.equals()` on null
2. For `Float` values (rotation, skew, skewAngle): auto-unboxing null to float
3. For `ScaleXY` values (scale): calling `.equals()` on null

## Evidence That Null Values Are Expected

The existence of `ensureValidRotationKeyframes()` method in the same file explicitly checks for and handles null `startValue`:

```java
} else if (rotation.getKeyframes().get(0).startValue == null) {
  rotation.getKeyframes().set(0, new Keyframe<>(...));
}
```

This demonstrates that null values can occur in practice from certain animation exports.

## The Fix

Added explicit null checks before accessing `startValue` in all identity check methods. If `startValue` is null, the transform is treated as non-identity, which is the safe default behavior that preserves the transform data in the parsed result.

## Testing

The fix is straightforward null-safety improvement. The behavior is:
- If `startValue` is null, return `false` (not identity) instead of crashing
- If `startValue` is not null, behavior is unchanged