### PR TITLE
Fix rotation ignored when the layer is autoorient

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/TransformKeyframeAnimation.java
+++ b/lottie/src/main/java/com/airbnb/lottie/animation/keyframe/TransformKeyframeAnimation.java
@@ -307,18 +307,17 @@ public class TransformKeyframeAnimation {
         double rotationValue = Math.toDegrees(Math.atan2(nextPosition.y - startY, nextPosition.x - startX));
         matrix.preRotate((float) rotationValue);
       }
-    } else {
-      BaseKeyframeAnimation<Float, Float> rotation = this.rotation;
-      if (rotation != null) {
-        float rotationValue;
-        if (rotation instanceof ValueCallbackKeyframeAnimation) {
-          rotationValue = rotation.getValue();
-        } else {
-          rotationValue = ((FloatKeyframeAnimation) rotation).getFloatValue();
-        }
-        if (rotationValue != 0f) {
-          matrix.preRotate(rotationValue);
-        }
+    }
+    BaseKeyframeAnimation<Float, Float> rotation = this.rotation;
+    if (rotation != null) {
+      float rotationValue;
+      if (rotation instanceof ValueCallbackKeyframeAnimation) {
+        rotationValue = rotation.getValue();
+      } else {
+        rotationValue = ((FloatKeyframeAnimation) rotation).getFloatValue();
+      }
+      if (rotationValue != 0f) {
+        matrix.preRotate(rotationValue);
       }
     }
 


### PR DESCRIPTION
Keyframe rotation [should be applied](https://github.com/airbnb/lottie-web/blob/bede03d25d232826e0c9dca1733d542d8a7754fb/player/js/utils/TransformProperty.js#L67-L74)  together with autoorient rotation

Animation example: 
[star.json](https://github.com/user-attachments/files/25451563/star.json)

Before:
![before](https://github.com/user-attachments/assets/0df15878-69c7-4a1f-a6e6-e9145f849d5b)

After:
![after](https://github.com/user-attachments/assets/1663d70a-5c6d-4f0a-900a-a79096c578c5)

@gpeal 