### PR TITLE
Lottie: Validate Looper compatibility when retrieving from taskCache

### DIFF
--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -816,7 +816,11 @@ public class LottieCompositionFactory {
       task = new LottieTask<>(uiLooper, cachedComposition);
     }
     if (cacheKey != null && taskCache.containsKey(cacheKey)) {
-      task = taskCache.get(cacheKey);
+      LottieTask<LottieComposition> cachedTask = taskCache.get(cacheKey);
+      // Only reuse the task if the Looper matches!
+      if (cachedTask.getLooper() == uiLooper) {
+        task = cachedTask;
+      }
     }
     if (task != null) {
       if (onCached != null) {

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -818,7 +818,7 @@ public class LottieCompositionFactory {
     if (cacheKey != null && taskCache.containsKey(cacheKey)) {
       LottieTask<LottieComposition> cachedTask = taskCache.get(cacheKey);
       // Only reuse the task if the Looper matches!
-      if (cachedTask.getLooper() == uiLooper) {
+      if (cachedTask != null && cachedTask.getLooper() == uiLooper) {
         task = cachedTask;
       }
     }

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
@@ -61,11 +62,12 @@ import okio.Source;
 public class LottieCompositionFactory {
 
   /**
-   * Keep a map of cache keys to in-progress tasks and return them for new requests.
-   * Without this, simultaneous requests to parse a composition will trigger multiple parallel
-   * parse tasks prior to the cache getting populated.
+   * Keep a thread-safe map of cache keys to in-progress tasks and return them for new requests.
+   * This prevents simultaneous requests from triggering multiple parallel parse tasks and
+   * ensures safety when accessed from different UI threads (e.g., main vs. per-window UI thread).
    */
-  private static final Map<String, LottieTask<LottieComposition>> taskCache = new HashMap<>();
+  private static final Map<String, LottieTask<LottieComposition>> taskCache =
+      new ConcurrentHashMap<>();
   private static final Set<LottieTaskIdleListener> taskIdleListeners = new HashSet<>();
 
   /**
@@ -815,7 +817,7 @@ public class LottieCompositionFactory {
     if (cachedComposition != null) {
       task = new LottieTask<>(uiLooper, cachedComposition);
     }
-    if (cacheKey != null && taskCache.containsKey(cacheKey)) {
+    if (cacheKey != null) {
       LottieTask<LottieComposition> cachedTask = taskCache.get(cacheKey);
       // Only reuse the task if the Looper matches!
       if (cachedTask != null && cachedTask.getLooper() == uiLooper) {

--- a/lottie/src/main/java/com/airbnb/lottie/LottieTask.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieTask.java
@@ -90,6 +90,10 @@ public class LottieTask<T> {
     }
   }
 
+  public Looper getLooper() {
+    return uiHandler.getLooper();
+  }
+
   private void setResult(@Nullable LottieResult<T> result) {
     if (this.result != null) {
       throw new IllegalStateException("A task may only be set once.");


### PR DESCRIPTION
This is a follow up of https://github.com/airbnb/lottie-android/pull/2685

The static taskCache in LottieCompositionFactory can store LottieTasks created on different UI threads (e.g., the system main thread vs. a per-window UI thread like the Taskbar thread).

Previously, if an animation was requested on the Taskbar UI thread that had already been cached by the Main thread, the Factory would return the cached task. This task would then notify listeners on the wrong thread, leading to a CalledFromWrongThreadException when LottieAnimationView attempted to requestLayout().

This change:
1. Adds getLooper() to LottieTask to expose its target notification thread.
2. Updates LottieCompositionFactory.cache() to only reuse a cached task if its Looper matches the requested uiLooper.